### PR TITLE
adding unit tests, finishing removal of 'google' from namespace and comm...

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<phpunit
+    bootstrap="./tests/bootstrap.php"
+    backupGlobals="false"
+    colors="true"
+>
+    <testsuites>
+        <testsuite>
+            <directory prefix="test_" suffix=".php">./</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/templates/full-sitemaps.php
+++ b/templates/full-sitemaps.php
@@ -18,7 +18,7 @@
 	if ( ( $req_year == 0 ) && ( $req_month == 0 ) && ( $req_day == 0 ) ) {
 		echo '<sitemapindex xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
 		foreach ( $years as $year ) {
-			$query = new WP_Query( array( 'year' => $year, 'post_type' => 'mgs_sitemap' ) );
+			$query = new WP_Query( array( 'year' => $year, 'post_type' => Metro_Sitemap::$sitemap_cpt ) );
 			if ( $query->have_posts() ) {
 				echo '<sitemap>';
 				echo '<loc>'. home_url( '/sitemap.xml?yyyy=' . $year ) . '</loc>';
@@ -35,13 +35,13 @@
 			'orderby' => 'ID',
 			'order' => 'ASC',
 			'posts_per_page' => 1,
-			'post_type' => 'mgs_sitemap',
+			'post_type' => Metro_Sitemap::$sitemap_cpt,
 		);
 		$sitemap_query = new WP_Query( $sitemap_args );
 		if ( $sitemap_query->have_posts() ) {
 		   while ( $sitemap_query->have_posts() ) : 
 		   		$sitemap_query->the_post();
-				$sitemap_content = get_post_meta( get_the_ID(), 'mgs_sitemap_xml', true );
+				$sitemap_content = get_post_meta( get_the_ID(), 'msm_sitemap_xml', true );
 		   		echo $sitemap_content;
 		   endwhile;
 		} else {
@@ -64,7 +64,7 @@
 						'monthnum' => $m,
 						'day' => $d,
 						'post_type' => 'DESC',
-						'post_type' => 'mgs_sitemap',
+						'post_type' => Metro_Sitemap::$sitemap_cpt,
 					);
 					$query = new WP_Query( $sitemap_args );
 					if ( $query->have_posts() ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Bootstrap the testing environment
+ * Uses wordpress tests (http://github.com/nb/wordpress-tests/) which uses PHPUnit
+ * @package wordpress-plugin-tests
+ *
+ * Usage: change the below array to any plugin(s) you want activated during the tests
+ *        value should be the path to the plugin relative to /wp-content/
+ *
+ * Note: Do note change the name of this file. PHPUnit will automatically fire this file when run.
+ *
+ */
+ 
+ 
+$GLOBALS['wp_tests_options'] = array(
+	'active_plugins' => array( 'metro-sitemap/metro-sitemap.php' ),
+);
+
+require getenv( 'WP_TESTS_DIR' ) . '/includes/bootstrap.php';

--- a/tests/test_sitemap_creation.php
+++ b/tests/test_sitemap_creation.php
@@ -1,0 +1,104 @@
+<?php
+
+class WP_Test_Sitemap_Creation extends WP_UnitTestCase {
+	
+	public $core = null;
+	
+	private $posts = array();
+	private $posts_created = array();
+
+	/**
+	 * Generate posts and build the sitemap
+	 */
+	function setup() {
+		// add four posts; one each for the last four days.
+		for ( $i = 0; $i < 4; $i++ ) {
+			$post_data = array(
+				'post_title' => uniqid(),
+				'post_content' => uniqid(),
+				'post_status' => 'publish',
+			);
+			$post_data['post_date'] = $post_data['post_modified'] = date( 'Y' ). '-' . date('m') . '-' . ( date('d') - $i ) . ' 12:00:00';
+			$post_data['ID'] = wp_insert_post( $post_data );
+			$this->posts_created[] = $post_data['ID'];
+			$this->posts[] = $post_data;
+		}
+		$this->build_sitemaps();
+	}
+
+	/**
+	 * Remove the sample posts and the sitemap posts
+	 */
+	function teardown() {
+		$sitemaps = get_posts( array(
+			'post_type' => Metro_Sitemap::$sitemap_cpt,
+			'fields' => 'ids',
+			'posts_per_page' => -1,
+		) );
+		array_map( 'wp_delete_post', array_merge( $this->posts_created, $sitemaps ) );
+	}
+
+	/**
+	 * Examines the XML stored in the database after sitemap generation
+	 */
+	function test_sitemap_posts_were_created() {
+		global $post;
+		$sitemaps = get_posts( array(
+			'post_type' => Metro_Sitemap::$sitemap_cpt,
+			'fields' => 'ids',
+			'posts_per_page' => -1,
+		) );
+		$this->assertCount( 4, $sitemaps );
+		foreach ( $sitemaps as $i => $map_id ) {
+			$xml = get_post_meta( $map_id, 'msm_sitemap_xml', true );
+			$post_id = $this->posts[$i]['ID'];
+			$this->assertContains( 'p=' . $post_id, $xml );
+
+			$xml_struct = simplexml_load_string( $xml );
+			$this->assertNotEmpty( $xml_struct->url );
+			$this->assertNotEmpty( $xml_struct->url->loc );
+			$this->assertNotEmpty( $xml_struct->url->lastmod );
+			$this->assertContains( 'p=' . $post_id, (string) $xml_struct->url->loc );
+
+			$post = get_post( $post_id );
+			setup_postdata( $post );
+			$mod_date = get_the_modified_date( 'Y-m-d' ) . 'T' . get_the_modified_date( 'H:i:s' ) . 'Z';
+			$this->assertSame( $mod_date, (string) $xml_struct->url->lastmod );
+			wp_reset_postdata();
+		}
+	}
+
+	/**
+	 * Generate sitemaps; pretends to run cron six times
+	 */
+	private function build_sitemaps() {
+		_set_cron_array( array() ); // isolate our cron jobs.
+		Metro_Sitemap::reset_sitemap_data();
+		delete_option( 'msm_stop_processing' );
+		Metro_Sitemap::generate_full_sitemap();
+		update_option( 'msm_sitemap_create_in_progress', true );
+		$this->fake_cron(); // this year
+		$this->fake_cron(); // this month
+		$this->fake_cron(); // today
+		$this->fake_cron(); // yesterday
+		$this->fake_cron(); // two days ago
+		$this->fake_cron(); // three days ago
+	}
+
+	/**
+	 * Fakes a cron job
+	 */
+	private function fake_cron() {
+		$schedule = _get_cron_array();
+		foreach ( $schedule as $timestamp => $cron ) {
+			foreach ( $cron as $hook => $arg_wrapper ) {
+				if ( substr( $hook, 0, 3 ) !== 'msm' ) continue; // only run our own jobs.
+				$arg_struct = array_pop( $arg_wrapper );
+				$args = $arg_struct['args'][0];
+				wp_unschedule_event( $timestamp, $hook, $arg_struct['args'] );
+				do_action( $hook, $args );
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
Here's a pull request which adds a basic unit test that creates a sitemap out of four posts, then does a number of checks on the XML stored in the database. Because it uses WordPress's cron system to build the sitemaps, the code coverage is actually pretty decent, although it's not granular enough, and I'd like to test the template output as well, though this may be easier to achieve if we move its query logic out of the template and into the module.

I've also finished scrubbing references to 'google', added PHPDoc (I did it as I read the code so I'd understand it a little better), and took a shot at tweaking queue_nginx_cache_invalidation(), since it didn't look like it would work to me as it was.

I have a number of features I'd like to help build, which I'll add as issues.
