### PR TITLE
Disabling sitemap generation for private blogs.

### DIFF
--- a/includes/msm-sitemap-builder-cron.php
+++ b/includes/msm-sitemap-builder-cron.php
@@ -30,7 +30,7 @@ class MSM_Sitemap_Builder_Cron {
 	 */
 	public static function add_actions( $actions ) {
 		// No actions for private blogs
-		if ( Metro_Sitemap::is_blog_private() ) {
+		if ( ! Metro_Sitemap::is_blog_public() ) {
 			return $actions;
 		}
 
@@ -302,7 +302,7 @@ class MSM_Sitemap_Builder_Cron {
 	public static function find_next_day_to_process( $year, $month, $day ) {
 
 		$halt = get_option( 'msm_stop_processing' ) === true;
-		if ( $halt || Metro_Sitemap::is_blog_private() ) {
+		if ( $halt || ! Metro_Sitemap::is_blog_public() ) {
 			// Allow user to bail out of the current process, doesn't remove where the job got up to
 			// or If the blog became private while sitemaps were enabled, stop here.
 			delete_option( 'msm_stop_processing' );

--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -89,7 +89,7 @@ class Metro_Sitemap {
 		screen_icon();
 		echo '<h2>' . __( 'Sitemap', 'metro-sitemaps' ) . '</h2>';
 
-		if ( self::is_blog_private() ) {
+		if ( ! self::is_blog_public() ) {
 			self::show_action_message( __( 'Oops! Sitemaps are not supported on private blogs. Please make your blog public and try again.', 'metro-sitemaps' ), 'error' );
 			echo '</div>';
 			return;
@@ -186,8 +186,8 @@ class Metro_Sitemap {
 		return array_sum( $counts );
 	}
 	
-	public static function is_blog_private() {
-		return ( 1 != get_option( 'blog_public' ) );
+	public static function is_blog_public() {
+		return ( 1 == get_option( 'blog_public' ) );
 	}
 	
 	/**
@@ -228,7 +228,7 @@ class Metro_Sitemap {
 	 * Add cron jobs required to generate these sitemaps
 	 */
 	public static function sitemap_init_cron() {
-		if ( ! self::is_blog_private() && ! wp_next_scheduled( 'msm_cron_update_sitemap' ) ) {
+		if ( self::is_blog_public() && ! wp_next_scheduled( 'msm_cron_update_sitemap' ) ) {
 			wp_schedule_event( time(), 'ms-sitemap-15-min-cron-interval', 'msm_cron_update_sitemap' );
 		}
 	}

--- a/templates/full-sitemaps.php
+++ b/templates/full-sitemaps.php
@@ -1,6 +1,6 @@
 <?php
 
-	if ( Metro_Sitemap::is_blog_private() ) {
+	if ( ! Metro_Sitemap::is_blog_public() ) {
 		wp_die( 
 			__( 'Sorry, this site is not public so sitemaps are not available.', 'msm-sitemap' ),
 			__( 'Sitemap Not Available', 'msm-sitemap' ),


### PR DESCRIPTION
In response to #41. There is no point in creating sitemaps for private
blogs.

Behaviour for a public blog remains the same. On a private blog, msm will:
- Disable its cron job. This is done similarily to a halt if the site went
  from public to private while sitemap generation was running.
- Not show its main admin UI. Instead it shows an error message saying
  that the blog is private and the user should make it public to enable
  sitemaps.
- When a sitemap is requested an error message is displayed saying that
  the blog is private thus no sitemaps are available.

Closes #41
