### PR TITLE
Allowing html tags in sitemap messages.

### DIFF
--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -162,7 +162,7 @@ class Metro_Sitemap {
 		elseif ( $level === 'error' )
 			$class = 'error';
 
-		echo '<div class="' . esc_attr( $class ) . ' msm-sitemap-message"><p>' . esc_html( $message ) . '</p></div>';
+		echo '<div class="' . esc_attr( $class ) . ' msm-sitemap-message"><p>' . wp_kses( $message, wp_kses_allowed_html( 'post' ) ) . '</p></div>';
 	}
 		
 	/**


### PR DESCRIPTION
Allowing the same html tags allowed in posts inside the sitemap messages
outputted when a user action is performed. This is allows cleaner and
better-formatted messages.
