### PR TITLE
"Release" msm-sitemap

### DIFF
--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -3,8 +3,8 @@
 Plugin Name: Metro Sitemap
 Description: Comprehensive sitemaps for your WordPress site. Joint collaboration between Metro.co.uk, MAKE, Alley Interactive, and WordPress.com VIP.
 Author: Artur Synowiec, Paul Kevan, and others
-Version: 0.1
-Stable tag: 0.1
+Version: 1.0
+Stable tag: 1.0
 License: GPLv2
 */
 


### PR DESCRIPTION
I think it's safe to say that msm-sitemap is stable. Version it 1.0 and please tag a release as well so Composer doesn't need to pull from HEAD.

I'm not merging my own PR just in deference to wanting a check from someone with more experience. Correct me if you think this is a bad idea, please. :)