### PR TITLE
Do not autoload create in progress option.

### DIFF
--- a/includes/msm-sitemap-builder-cron.php
+++ b/includes/msm-sitemap-builder-cron.php
@@ -69,7 +69,12 @@ class MSM_Sitemap_Builder_Cron {
 	public static function action_generate() {
 		$sitemap_create_in_progress = get_option( 'msm_sitemap_create_in_progress' );
 		self::generate_full_sitemap();
-		update_option( 'msm_sitemap_create_in_progress', true );
+
+		if ( false !== get_option( 'msm_sitemap_create_in_progress', false ) ) {
+			update_option( 'msm_sitemap_create_in_progress', true );
+		} else {
+			add_option( 'msm_sitemap_create_in_progress', true, '', 'no' );
+		}
 
 		if ( empty( $sitemap_create_in_progress ) ) {
 			Metro_Sitemap::show_action_message( __( 'Starting sitemap generation...', 'metro-sitemaps' ) );


### PR DESCRIPTION
The "msm_sitemap_create_in_progress" is critical to fully stop the
progress of the sitemap generation. It is stored as an autoloading
option, which is unfortunately susceptible to bizarre race conditions
(https://core.trac.wordpress.org/ticket/31245). Deleting this option can
be problematic because it gets stuck in the cache, thereby causing
problems with resetting the state.

This commit fixes the issue by explicitly setting the option to not be
autoloaded