### PR TITLE
Add kill switch for cron.

### DIFF
--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -32,6 +32,9 @@ class Metro_Sitemap {
 		add_action( 'init', array( __CLASS__, 'create_post_type' ) );
 		add_filter( 'template_include', array( __CLASS__, 'load_sitemap_template' ) );
 
+		// Potentially disable cron based on a kill switch
+		add_filter( 'msm_sitemap_use_cron_builder', array( __CLASS__, 'maybe_use_cron' ) );
+
 		// By default, we use wp-cron to help generate the full sitemap.
 		// However, this will let us override it, if necessary, like on WP.com
 		if ( true === apply_filters( 'msm_sitemap_use_cron_builder', true ) ) {
@@ -664,6 +667,10 @@ class Metro_Sitemap {
 
 	public static function get_supported_post_types() {
 		return apply_filters( 'msm_sitemap_entry_post_type', array( 'post' ) );
+	}
+
+	public function maybe_use_cron( $enable ) {
+		return ( 'yes' === get_option( 'msm_disable_cron', false ) ) ? false : $enable;
 	}
 
 	private static function get_supported_post_types_in() {


### PR DESCRIPTION
When initially deploying this plugin, hundreds or thousands of cron
event can be created to generate site maps over time. While this may be
desirable for some, others may want to generate the sitemaps manually
with WP CLI.

In order to do this without the interference of cron, there needs to be
a way to shut down the cron events temporarily. This PR does just that.

`wp msm-sitemaps cron --disable` is introduced to set a option variable.
When this option variable is set, the cron file is not loaded and thus
the actions tied to the cron events won't execute. Additionally, the
command removes all of the `msm_cron_generate_sitemap_for_year_month_day`
events from the cron event list. This is more or less for cleaning up
that list for sanity.

Once a developer wants to enable cron events again, she can do so with
`wp msm-sitemaps cron --enable`. This removes the option that blocks the
cron file from loading.

While I've explained this PR in the context of a specific use case, this
cron disabling feature is also useful if a developer deploys this plugin
and needs a quick way to kill the cron actions (perhaps the sitemap
generation has caused too much load).

Note that this does not affect the `msm_cron_update_sitemap` which is
part of the main plugin file. This is because it is not part of the cron
file. Additionally, this cron action is harmless without the
accompanying cron file.