### PR TITLE
Added fiter for xml builder

### DIFF
--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -644,6 +644,9 @@ class Metro_Sitemap {
 			/* Invalid options sent */
 			return false;
 		}
+		
+		$xml = apply_filters( 'msm_sitemap_build_xml', $xml, $request );
+
 		return $xml;
 	}
 


### PR DESCRIPTION
We have errors with the sitemap, due to the presence of of "&amp" string in the links. For this reason, we want to be able to apply a filter to all XML document.

Example: /sitemap.xml?yyyy=2015&amp ;mm=12&amp ;dd=24