### PR TITLE
Delete Empty Sitemaps

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+
+WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
+
+download() {
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
+    elif [ `which wget` ]; then
+        wget -nv -O "$2" "$1"
+    fi
+}
+
+if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
+	WP_TESTS_TAG="tags/$WP_VERSION"
+else
+	# http serves a single offer, whereas https serves multiple
+	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
+	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+	if [[ -z "$LATEST_VERSION" ]]; then
+		echo "Latest WordPress version could not be found"
+		exit 1
+	fi
+	WP_TESTS_TAG="tags/$LATEST_VERSION"
+fi
+
+set -ex
+
+install_wp() {
+
+	if [ -d $WP_CORE_DIR ]; then
+		return;
+	fi
+
+	mkdir -p $WP_CORE_DIR
+
+	if [ $WP_VERSION == 'latest' ]; then
+		local ARCHIVE_NAME='latest'
+	else
+		local ARCHIVE_NAME="wordpress-$WP_VERSION"
+	fi
+
+	download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
+	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
+
+	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+}
+
+install_test_suite() {
+	# portable in-place argument for both GNU sed and Mac OSX sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i .bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite if it doesn't yet exist
+	if [ ! -d $WP_TESTS_DIR ]; then
+		# set up testing suite
+		mkdir -p $WP_TESTS_DIR
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+	fi
+
+	cd $WP_TESTS_DIR
+
+	if [ ! -f wp-tests-config.php ]; then
+		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+	fi
+
+}
+
+install_db() {
+	# parse DB_HOST for port or socket references
+	local PARTS=(${DB_HOST//\:/ })
+	local DB_HOSTNAME=${PARTS[0]};
+	local DB_SOCK_OR_PORT=${PARTS[1]};
+	local EXTRA=""
+
+	if ! [ -z $DB_HOSTNAME ] ; then
+		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+			EXTRA=" --socket=$DB_SOCK_OR_PORT"
+		elif ! [ -z $DB_HOSTNAME ] ; then
+			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+		fi
+	fi
+
+	# create database
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
+install_wp
+install_test_suite
+install_db

--- a/includes/msm-sitemap-builder-cron.php
+++ b/includes/msm-sitemap-builder-cron.php
@@ -305,6 +305,8 @@ class MSM_Sitemap_Builder_Cron {
 		$date_stamp = Metro_Sitemap::get_date_stamp( $year, $month, $day );
 		if ( Metro_Sitemap::date_range_has_posts( $date_stamp, $date_stamp ) ) {
 			Metro_Sitemap::generate_sitemap_for_date( $date_stamp );
+		} else {
+			Metro_Sitemap::delete_sitemap_for_date( $date_stamp );
 		}
 
 		self::find_next_day_to_process( $year, $month, $day );

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -148,6 +148,8 @@ class Metro_Sitemap_CLI extends WP_CLI_Command {
 		$date_stamp = Metro_Sitemap::get_date_stamp( $year, $month, $day );
 		if ( Metro_Sitemap::date_range_has_posts( $date_stamp, $date_stamp ) ) {
 			Metro_Sitemap::generate_sitemap_for_date( $date_stamp ); // TODO: simplify; this function should accept the year, month, day and translate accordingly
+		} else {
+			Metro_Sitemap::delete_sitemap_for_date( $date_stamp );
 		}
 	}
 

--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -395,10 +395,7 @@ class Metro_Sitemap {
 		if ( ! $post_count ) {
 			// If no entries - delete the whole sitemap post
 			if ( $sitemap_exists ) {
-				$total_url_count -= intval( get_post_meta( $sitemap_id, 'msm_indexed_url_count', true ) );
-				update_option( 'msm_sitemap_indexed_url_count' , $total_url_count );
-				wp_delete_post( $sitemap_id, true );
-				do_action( 'msm_delete_sitemap_post', $sitemap_id, $year, $month, $day );
+				self::delete_sitemap_by_id( $sitemap_id );
 			}
 			return;
 		}
@@ -466,6 +463,32 @@ class Metro_Sitemap {
 		update_option( 'msm_sitemap_indexed_url_count' , $total_url_count );
 
 		wp_reset_postdata();
+	}
+
+	public static function delete_sitemap_for_date( $sitemap_date ) {
+		list( $year, $month, $day ) = explode( '-', $sitemap_date );
+		$sitemap_id = self::get_sitemap_post_id( $year, $month, $day );
+		if ( ! $sitemap_id ) {
+			return false;
+		}
+		return self::delete_sitemap_by_id( $sitemap_id );
+	}
+
+	public static function delete_sitemap_by_id( $sitemap_id ) {
+		$sitemap = get_post( $sitemap_id );
+		if ( ! $sitemap ) {
+			return false;
+		}
+
+		$sitemap_date = date( 'Y-m-d', strtotime( $sitemap->post_date ) );
+		list( $year, $month, $day ) = explode( '-', $sitemap_date );
+
+		$total_url_count = self::get_total_indexed_url_count();
+		$total_url_count -= intval( get_post_meta( $sitemap_id, 'msm_indexed_url_count', true ) );
+		update_option( 'msm_sitemap_indexed_url_count' , $total_url_count );
+
+		wp_delete_post( $sitemap_id, true );
+		do_action( 'msm_delete_sitemap_post', $sitemap_id, $year, $month, $day );
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,19 +1,15 @@
 <?php
-/**
- * Bootstrap the testing environment
- * Uses wordpress tests (http://github.com/nb/wordpress-tests/) which uses PHPUnit
- * @package wordpress-plugin-tests
- *
- * Usage: change the below array to any plugin(s) you want activated during the tests
- *        value should be the path to the plugin relative to /wp-content/
- *
- * Note: Do note change the name of this file. PHPUnit will automatically fire this file when run.
- *
- */
- 
- 
-$GLOBALS['wp_tests_options'] = array(
-	'active_plugins' => array( 'msm-sitemap/msm-sitemap.php' ),
-);
 
-require getenv( 'WP_TESTS_DIR' ) . '/includes/bootstrap.php';
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+if ( ! $_tests_dir ) {
+	$_tests_dir = '/tmp/wordpress-tests-lib';
+}
+
+require_once $_tests_dir . '/includes/functions.php';
+
+function _manually_load_plugin() {
+	require dirname( dirname( __FILE__ ) ) . '/msm-sitemap.php';
+}
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+require $_tests_dir . '/includes/bootstrap.php';


### PR DESCRIPTION
When a sitemap has no posts, delete it. Do this for both cron and CLI. Otherwise we end up with rogue empty sitemaps. Previously, we were doing the empty posts check during the generate call. Both Cron and CLI skip doing the generate if we have no posts.

Fixes #63 #67 and #69