### PR TITLE
Ensure cron events are scheduled with consistent data types in their arguments

### DIFF
--- a/includes/msm-sitemap-builder-cron.php
+++ b/includes/msm-sitemap-builder-cron.php
@@ -159,9 +159,9 @@ class MSM_Sitemap_Builder_Cron {
 			'msm_cron_generate_sitemap_for_year_month_day',
 			array(
 				array(
-					'year' => $year,
-					'month' => $month,
-					'day' => $day,
+					'year' => (int) $year,
+					'month' => (int) $month,
+					'day' => (int) $day,
 					),
 				)
 			);
@@ -206,7 +206,7 @@ class MSM_Sitemap_Builder_Cron {
 			'msm_cron_generate_sitemap_for_year', 
 			array(
 				array(
-					'year' => $next_year,
+					'year' => (int) $next_year,
 					),
 				)
 			);
@@ -240,8 +240,8 @@ class MSM_Sitemap_Builder_Cron {
 			'msm_cron_generate_sitemap_for_year_month',
 			array(
 				array(
-					'year' => $year,
-					'month' => $next_month,
+					'year' => (int) $year,
+					'month' => (int) $next_month,
 					),
 				)
 			);
@@ -284,9 +284,9 @@ class MSM_Sitemap_Builder_Cron {
 			'msm_cron_generate_sitemap_for_year_month_day',
 			array(
 				array(
-					'year' => $year,
-					'month' => $month,
-					'day' => $next_day,
+					'year' => (int) $year,
+					'month' => (int) $month,
+					'day' => (int) $next_day,
 					),
 				)
 			);

--- a/vipgo-helper.php
+++ b/vipgo-helper.php
@@ -15,9 +15,9 @@ function vipgo_schedule_sitemap_update_for_year_month_date( $date, $time ) {
 		'msm_vipgo_cron_generate_sitemap_for_year_month_day',
 		array(
 			array(
-				'year' => $year,
-				'month' => $month,
-				'day' => $day,
+				'year' => (int) $year,
+				'month' => (int) $month,
+				'day' => (int) $day,
 			),
 		)
 	);


### PR DESCRIPTION
Core's cron functions compare arguments arrays in several places, notably when checking for existing events, and inconsistent data types break those checks.

Fixes #89