### PR TITLE
Switch to raw SQL from WP_Date_Query

### DIFF
--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -398,6 +398,7 @@ class Metro_Sitemap {
 			return;
 		}
 
+		// We need to get a WP_Query object for back-compat as we run a Loop when building
 		$query = new WP_Query( array(
 			'post__in' => $post_ids,
 			'no_found_rows' => true,


### PR DESCRIPTION
Using a direct comparison against post_date is significantly faster than
the date casting queries generated by WP_Date_Query. The former does a
range query which results in a much smaller dataset to look through. The
latter does a ref which has to scan a much larger dataset, which on
larger sites is significantly slower.

```
# Before
mysql> EXPLAIN SELECT   wp_posts.* FROM wp_posts  WHERE 1=1  AND (
    ->   ( YEAR( wp_posts.post_date ) = 2016 AND MONTH( wp_posts.post_date ) = 10 AND DAYOFMONTH( wp_posts.post_date ) = 7 )
    -> ) AND wp_posts.post_type = 'post' AND ((wp_posts.post_status = 'publish'))  ORDER BY wp_posts.post_date DESC LIMIT 0, 500;
+------+-------------+----------+------+------------------+------------------+---------+-------------+--------+-------------+
| id   | select_type | table    | type | possible_keys    | key              | key_len | ref         | rows   | Extra       |
+------+-------------+----------+------+------------------+------------------+---------+-------------+--------+-------------+
|    1 | SIMPLE      | wp_posts | ref  | type_status_date | type_status_date | 164     | const,const | 864750 | Using where |
+------+-------------+----------+------+------------------+------------------+---------+-------------+--------+-------------+
1 row in set (0.00 sec)

# After

mysql> EXPLAIN SELECT wp_posts.* FROM wp_posts  WHERE 1=1  AND ( wp_posts.post_date >= '2016-10-07 00:00:00' AND wp_posts.post_date <= '2016-10-07 23:59:59' ) AND wp_posts.post_type = 'post' AND ((wp_posts.post_status = 'publish'))  ORDER BY wp_posts.post_date DESC LIMIT 0, 500;
+------+-------------+----------+-------+------------------+------------------+---------+------+------+-------------+
| id   | select_type | table    | type  | possible_keys    | key              | key_len | ref  | rows | Extra       |
+------+-------------+----------+-------+------------------+------------------+---------+------+------+-------------+
|    1 | SIMPLE      | wp_posts | range | type_status_date | type_status_date | 169     | NULL |  106 | Using where |
+------+-------------+----------+-------+------------------+------------------+---------+------+------+-------------+
1 row in set (0.00 sec)
```

Query time differences between the two examples were 0.74s before and 0.00s after.
