### PR TITLE
Adding post_type, posts_per_page and post_status to WP_Query used in …

### DIFF
--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -401,8 +401,11 @@ class Metro_Sitemap {
 		// We need to get a WP_Query object for back-compat as we run a Loop when building
 		$query = new WP_Query( array(
 			'post__in' => $post_ids,
+			'post_type' => self::get_supported_post_types(),
 			'no_found_rows' => true,
+			'posts_per_page' => $per_page,
 			'ignore_sticky_posts' => true,
+			'post_status' => 'publish',
 		) );
 		$post_count = $query->post_count;
 


### PR DESCRIPTION
…generate_sitemap_for_date

Since we are obtaining various post_types ( obtained via `Metro_Sitemap::get_supported_post_types_in` ) in `Metro_Sitemap::get_post_ids_for_date` function, and since we are querying for `post_status` equal to `publish` only in the same function, and since we are querying more than default number of posts (usually 10) in that function (passed in as $limit param with default value of 500 ), we need to reflect those facts in the `WP_Query` called in `Metro_Sitemap::generate_sitemap_for_date`.

The `WP_Query` currently does not specify the `post_type`, `post_status` nor `posts_per_page` and thus WordPress goes with default values being:

* post for post_type
* 10 or any other default number of posts_per_page
* any readable post stati for current user, depending on user's role

This leads to the issues with number of items in the page being displayed and to issues with custom post types - (not being displayed)

This commit is fixing all the issues by specifying `post_status` in WP_Query (`'publish'`), specifying `posts_per_page` (taking advantage of existing `$per_page` variable) and `post_type` to the result of `Metro_Sitemap::get_supported_post_types_in()` call.

Those issues were introduced in #93 (cc @mjangda )