### PR TITLE
Resolves issue #98 where if no posts exist oldest year is set to 1970…

### DIFF
--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -294,9 +294,9 @@ class Metro_Sitemap {
 			$oldest_post_year = date( 'Y', strtotime( $oldest_post_date_gmt ) );
 			$current_year = date( 'Y' );
 			return range( $oldest_post_year, $current_year );
-		} else {
-			return array();
 		}
+		
+		return array();
 
 	}
 

--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -289,8 +289,11 @@ class Metro_Sitemap {
 		global $wpdb;
 
 		$oldest_post_date_gmt = $wpdb->get_var( "SELECT post_date FROM $wpdb->posts WHERE post_status = 'publish' ORDER BY post_date ASC LIMIT 1" );
-		$oldest_post_year = date( 'Y', strtotime( $oldest_post_date_gmt ) );
-		$current_year = date( 'Y' );
+		
+		$oldest_post_year = $current_year = date( 'Y' );
+		if( null !== $oldest_post_date_gmt ) {
+			$oldest_post_year = date( 'Y', strtotime( $oldest_post_date_gmt ) );
+		}
 
 		return range( $oldest_post_year, $current_year );
 	}

--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -290,12 +290,14 @@ class Metro_Sitemap {
 
 		$oldest_post_date_gmt = $wpdb->get_var( "SELECT post_date FROM $wpdb->posts WHERE post_status = 'publish' ORDER BY post_date ASC LIMIT 1" );
 		
-		$oldest_post_year = $current_year = date( 'Y' );
 		if( null !== $oldest_post_date_gmt ) {
 			$oldest_post_year = date( 'Y', strtotime( $oldest_post_date_gmt ) );
+			$current_year = date( 'Y' );
+			return range( $oldest_post_year, $current_year );
+		} else {
+			return array();
 		}
 
-		return range( $oldest_post_year, $current_year );
 	}
 
 	/**


### PR DESCRIPTION
Pull requests updates logic for get_post_year_range to handle an empty db. Initially set oldest post date to current year and only update if query returns a result.