### PR TITLE
Escape loc url

### DIFF
--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -448,7 +448,7 @@ class Metro_Sitemap {
 				continue;
 
 			$url = $xml->addChild( 'url' );
-			$url->addChild( 'loc', get_permalink() );
+			$url->addChild( 'loc', esc_url( get_permalink() ) );
 			$url->addChild( 'lastmod', get_post_modified_time( 'c', true ) );
 			$url->addChild( 'changefreq', 'monthly' );
 			$url->addChild( 'priority', '0.7' );


### PR DESCRIPTION
Prevents warnings/failures when a permalink for a post has an entity like `&`:

```
Warning: SimpleXMLElement::addChild(): unterminated entity reference utm_medium=xyz&utm_campaign=abc in msm-sitemap/msm-sitemap.php on line 446
```