### PR TITLE
Optimize get_last_modified_posts query

### DIFF
--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -553,7 +553,7 @@ class Metro_Sitemap {
 
 		$post_types_in = self::get_supported_post_types_in();
 
-		$modified_posts = $wpdb->get_results( $wpdb->prepare( "SELECT ID, post_date FROM $wpdb->posts WHERE post_type IN ( {$post_types_in} ) AND post_modified_gmt >= %s ORDER BY post_date LIMIT 1000", $date ) );
+		$modified_posts = $wpdb->get_results( $wpdb->prepare( "SELECT ID, post_date FROM $wpdb->posts WHERE post_type IN ( {$post_types_in} ) AND post_modified_gmt >= %s LIMIT 1000", $date ) );
 		return $modified_posts;
 	}
 


### PR DESCRIPTION
Remove ORDER BY clause since we don't actually need it (we end up looping through and grabbing unique Y-m-d entries from the results). The `ORDER BY` adds a filesort to the query which can slow things down a lot.

```
### Before

mysql> EXPLAIN SELECT ID, post_date FROM wp_posts WHERE post_type IN ( 'post' ) AND post_modified_gmt >= '2017-01-19 06:25:46' ORDER BY post_date LIMIT 1000;
+------+-------------+----------+------+------------------+------------------+---------+-------+--------+----------------------------------------------------+
| id   | select_type | table    | type | possible_keys    | key              | key_len | ref   | rows   | Extra                                              |
+------+-------------+----------+------+------------------+------------------+---------+-------+--------+----------------------------------------------------+
|    1 | SIMPLE      | wp_posts | ref  | type_status_date | type_status_date | 82      | const | 928163 | Using index condition; Using where; Using filesort |
+------+-------------+----------+------+------------------+------------------+---------+-------+--------+----------------------------------------------------+

### After

mysql> EXPLAIN SELECT ID, post_date FROM wp_posts WHERE post_type IN ( 'post' ) AND post_modified_gmt >= '2017-01-19 06:25:46' LIMIT 1000;
+------+-------------+----------+------+------------------+------------------+---------+-------+--------+------------------------------------+
| id   | select_type | table    | type | possible_keys    | key              | key_len | ref   | rows   | Extra                              |
+------+-------------+----------+------+------------------+------------------+---------+-------+--------+------------------------------------+
|    1 | SIMPLE      | wp_posts | ref  | type_status_date | type_status_date | 82      | const | 928163 | Using index condition; Using where |
+------+-------------+----------+------+------------------+------------------+---------+-------+--------+------------------------------------+
1 row in set (0.00 sec)
```