### PR TITLE
Issue 110

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+.DS_Store

--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -451,6 +451,10 @@ class Metro_Sitemap {
 			// Update the total post count with the difference
 			$total_url_count += $url_count - $previous_url_count;
 
+			// Since we've changed the key name, we can let this snippet of code handle cleanup for us.
+            // Theoretically we can remove this after a given period of time
+			delete_post_meta( $sitemap_id, 'msm_sitemap_xml');
+
 			update_post_meta( $sitemap_id, 'msm_sitemap_data', serialize( $sitemap_post_data ) );
 			update_post_meta( $sitemap_id, 'msm_indexed_url_count', $url_count );
 			do_action( 'msm_update_sitemap_post', $sitemap_id, $year, $month, $day );

--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -423,22 +423,21 @@ class Metro_Sitemap {
 			update_option( 'msm_sitemap_indexed_url_count', $total_url_count );
 		}
 
-
-
 		$url_count = 0;
 		$sitemap_post_data = [];
+
 		while ( $query->have_posts() ) {
 			$query->the_post();
 
 			if ( apply_filters( 'msm_sitemap_skip_post', false ) )
 				continue;
 
-            array_push($sitemap_post_data, [
-	            'loc' => esc_url( get_permalink() ),
-	            'lastmod' => get_post_modified_time( 'c', true ),
-	            'changefreq' => 'monthly',
-	            'priority' => '0.7',
-            ]);
+                array_push($sitemap_post_data, [
+                    'loc' => esc_url( get_permalink() ),
+                    'lastmod' => get_post_modified_time( 'c', true ),
+                    'changefreq' => 'monthly',
+                    'priority' => '0.7',
+                ]);
 
 			++$url_count;
 			// TODO: add images to sitemap via <image:image> tag
@@ -452,13 +451,13 @@ class Metro_Sitemap {
 			// Update the total post count with the difference
 			$total_url_count += $url_count - $previous_url_count;
 
-			update_post_meta( $sitemap_id, 'msm_sitemap_xml', serialize( $sitemap_post_data ) );
+			update_post_meta( $sitemap_id, 'msm_sitemap_data', serialize( $sitemap_post_data ) );
 			update_post_meta( $sitemap_id, 'msm_indexed_url_count', $url_count );
 			do_action( 'msm_update_sitemap_post', $sitemap_id, $year, $month, $day );
 		} else {
 			/* Should no longer hit this */
 			$sitemap_id = wp_insert_post( $sitemap_data );
-			add_post_meta( $sitemap_id, 'msm_sitemap_xml', serialize( $sitemap_post_data ) );
+			add_post_meta( $sitemap_id, 'msm_sitemap_data', serialize( $sitemap_post_data ) );
 			add_post_meta( $sitemap_id, 'msm_indexed_url_count', $url_count );
 			do_action( 'msm_insert_sitemap_post', $sitemap_id, $year, $month, $day );
 
@@ -670,7 +669,8 @@ class Metro_Sitemap {
 		$sitemap_id = self::get_sitemap_post_id( $year, $month, $day );
 
 		if ( $sitemap_id ) {
-			$sitemap_content = get_post_meta( $sitemap_id, 'msm_sitemap_xml', true );
+			$sitemap_content = get_post_meta( $sitemap_id, 'msm_sitemap_data', true );
+
             // SimpleXML doesn't allow us to define namespaces using addAttribute, so we need to specify them in the construction instead.
             $namespaces = apply_filters( 'msm_sitemap_namespace', array(
                 'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
@@ -681,13 +681,16 @@ class Metro_Sitemap {
             ) );
 
             $namespace_str = '<?xml version="1.0" encoding="utf-8"?><urlset';
+
             foreach ( $namespaces as $ns => $value ) {
                 $namespace_str .= sprintf( ' %s="%s"', esc_attr( $ns ), esc_attr( $value ) );
             }
+
             $namespace_str .= '></urlset>';
 
 			$xml = new SimpleXMLElement( $namespace_str );
-            $sitemap_content_data = unserialize($sitemap_content);
+
+			$sitemap_content_data = unserialize($sitemap_content);
 
             foreach( $sitemap_content_data as $sitemap_item ) {
 	            $url = $xml->addChild( 'url' );

--- a/templates/full-sitemaps.php
+++ b/templates/full-sitemaps.php
@@ -1,5 +1,5 @@
 <?php
-
+timer_start();
 if ( ! Metro_Sitemap::is_blog_public() ) {
 	wp_die( 
 		__( 'Sorry, this site is not public so sitemaps are not available.', 'msm-sitemap' ),
@@ -15,7 +15,7 @@ $req_day = ( isset( $_GET['dd'] ) ) ? intval( $_GET['dd'] ) : false;
 $build_xml = Metro_Sitemap::build_xml( array( 'year' => $req_year, 'month' => $req_month, 'day' => $req_day ) );
 
 if ( $build_xml === false ) {
-	wp_die( 
+	wp_die(
 		__( 'Sorry, no sitemap available here.', 'msm-sitemap' ),
 		__( 'Sitemap Not Available', 'msm-sitemap' ),
 		array ( 'response' => 404 )

--- a/tests/test-sitemap-creation.php
+++ b/tests/test-sitemap-creation.php
@@ -79,21 +79,21 @@ class WP_Test_Sitemap_Creation extends WP_UnitTestCase {
 		$this->assertCount( $this->num_days, $sitemaps );
 
 		foreach ( $sitemaps as $i => $map_id ) {
-			$xml = get_post_meta( $map_id, 'msm_sitemap_xml', true );
+			$sitemap_data = get_post_meta( $map_id, 'msm_sitemap_data', true );
 			$post_id = $this->test_base->posts[ $i ]['ID'];
 			$this->assertContains( 'p=' . $post_id, $xml );
 
-			$xml_struct = simplexml_load_string( $xml );
-			$this->assertNotEmpty( $xml_struct->url );
-			$this->assertNotEmpty( $xml_struct->url->loc );
-			$this->assertNotEmpty( $xml_struct->url->lastmod );
-			$this->assertContains( 'p=' . $post_id, (string) $xml_struct->url->loc );
+			$sitemap_data = unserialize($sitemap_data);
+			$this->assertNotEmpty($sitemap_data[0]);
+			$this->assertNotEmpty($sitemap_data[0]['loc']);
+			$this->assertNotEmpty($sitemap_data[0]['lastmod']);
+			$this->assertContains( 'p=' . $post_id, $sitemap_data[0]['loc'] );
 
 			$post = get_post( $post_id );
 			setup_postdata( $post );
 			$mod_date = get_the_modified_date( 'c' );
-			$xml_date = (string) $xml_struct->url->lastmod;
-			$this->assertSame( $mod_date, $xml_date );
+			$sitemap_date = $sitemap_data[0]['lastmod'];
+			$this->assertSame( $mod_date, $sitemap_date );
 			wp_reset_postdata();
 		}
 	}


### PR DESCRIPTION
I've switched the generation to generate serialized data. Then that get's formatted on the front end with SimpleXML so we retain the benefits and abilities of using that. 

Performance wise your inserts/generation should be unaffected. (Or if it is affected, it's only marginal). We're still inserting text data but it's not formatted as XML anymore

The front end render seems to be okay, the default 500 page limit is around .002 seconds to render and if we up that to 5000 it's around .04 seconds to render. 