### PR TITLE
Fix tests in PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
      env: WP_VERSION=4.7
      # 7.0 / latest already included above as first build.
    - php: "7.0"
-     env: WP_VERSION=4.7
+     env: WP_VERSION=latest
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"


### PR DESCRIPTION
Tests are currently broken in PHP7, when using WordPress 4.7. This commit bounces the version used along with php7 to latest.