### PR TITLE
Improve MSM_Sitemap::get_post_ids_for_date SQL's performance by sorting by date via PHP.

### DIFF
--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -398,7 +398,13 @@ class Metro_Sitemap {
 		$end_date = $sitemap_date . ' 23:59:59';
 		$post_types_in = self::get_supported_post_types_in();
 
-		return $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_status = 'publish' AND post_date >= %s AND post_date <= %s AND post_type IN ( {$post_types_in} ) ORDER BY post_date LIMIT %d", $start_date, $end_date, $limit ) );
+		$posts = $wpdb->get_results( $wpdb->prepare( "SELECT ID, post_date FROM $wpdb->posts WHERE post_status = 'publish' AND post_date >= %s AND post_date <= %s AND post_type IN ( {$post_types_in} ) LIMIT %d", $start_date, $end_date, $limit ) );
+
+		usort( $posts, array( __CLASS__ , 'order_by_post_date' ) );
+
+		$post_ids = wp_list_pluck( $posts, 'ID' );
+
+		return array_map( 'intval', $post_ids );
 	}
 
 	/**
@@ -797,6 +803,23 @@ class Metro_Sitemap {
 		}
 
 		return implode( ', ', $post_types_prepared );
+	}
+
+	/**
+	 * Helper function for PHP ordering of posts by date, desc.
+	 *
+	 * @param object $post_a StdClass object, or WP_Post object to order.
+	 * @param object $post_b StdClass object or WP_Post object to order.
+	 *
+	 * @return int
+	 */
+	private static function order_by_post_date( $post_a, $post_b ) {
+		$a_date = strtotime( $post_a->post_date );
+		$b_date = strtotime( $post_b->post_date );
+		if ( $a_date === $b_date ) {
+			return 0;
+		}
+		return ( $a_date < $b_date ) ? -1 : 1;
 	}
 }
 

--- a/tests/msm-sitemap-test.php
+++ b/tests/msm-sitemap-test.php
@@ -36,6 +36,8 @@ class MSM_SiteMap_Test {
 	 * @param str $post_type The Post Type Slug.
 	 * @param str @post_status The status of the created post.
 	 * @throws Exception Unable to insert posts.
+	 *
+	 * @return int ID of created post.
 	 */
 	function create_dummy_post( $day, $post_status = 'publish', $post_type = 'post' ) {
 		$post_data = array(
@@ -55,6 +57,8 @@ class MSM_SiteMap_Test {
 
 		$this->posts_created[] = $post_data['ID'];
 		$this->posts[] = $post_data;
+
+		return $post_data['ID'];
 	}
 	
 	/**

--- a/tests/test-sitemap-functions.php
+++ b/tests/test-sitemap-functions.php
@@ -257,13 +257,19 @@ class WP_Test_Sitemap_Functions extends WP_UnitTestCase {
 		// 1 for 2016-10-03 in "draft" status.
 		$this->test_base->create_dummy_post( '2016-10-01 00:00:00', 'draft' );
 
+		$created_post_ids = array();
 		// 20 for 2016-10-02.
 		for ( $i = 0; $i < 20; $i ++ ) {
-			$this->test_base->create_dummy_post( '2016-10-02 00:00:00' );
+			$hour = $i < 10 ? '0' . $i : $i;
+			if ( '2016-10-02' === $sitemap_date ) {
+				$created_post_ids[] = $this->test_base->create_dummy_post( '2016-10-02 ' . $hour . ':00:00' );
+			}
 		}
+
 
 		$post_ids = Metro_Sitemap::get_post_ids_for_date( $sitemap_date, $limit );
 		$this->assertEquals( $expected_count, count( $post_ids ) );
+		$this->assertEquals( array_slice( $created_post_ids, 0, $limit ), $post_ids );
 
 	}
 


### PR DESCRIPTION
Sorting by post date in PHP halves the time necessary for querying posts from database.

This commit also contains adjusted tests, so they now not only assert the count, but also the order, which should cover this changeset.