### PR TITLE
Remove extra wp query

### DIFF
--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -398,7 +398,7 @@ class Metro_Sitemap {
 		$end_date = $sitemap_date . ' 23:59:59';
 		$post_types_in = self::get_supported_post_types_in();
 
-		$posts = $wpdb->get_results( $wpdb->prepare( "SELECT ID, post_date FROM $wpdb->posts WHERE post_status = 'publish' AND post_date >= %s AND post_date <= %s AND post_type IN ( {$post_types_in} ) ORDER BY post_date LIMIT %d", $start_date, $end_date, $limit ) );
+		$posts = $wpdb->get_results( $wpdb->prepare( "SELECT ID, post_date FROM $wpdb->posts WHERE post_status = 'publish' AND post_date >= %s AND post_date <= %s AND post_type IN ( {$post_types_in} ) LIMIT %d", $start_date, $end_date, $limit ) );
 
 		usort( $posts, array( __CLASS__ , 'order_by_post_date' ) );
 

--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -435,9 +435,9 @@ class Metro_Sitemap {
 		}
 
 		$per_page = apply_filters( 'msm_sitemap_entry_posts_per_page', self::DEFAULT_POSTS_PER_SITEMAP_PAGE );
-		$posts = self::get_post_ids_for_date( $sitemap_date, $per_page );
+		$posts_ids = self::get_post_ids_for_date( $sitemap_date, $per_page );
 
-		if ( empty( $posts ) ) {
+		if ( empty( $posts_ids ) ) {
 			// If no entries - delete the whole sitemap post
 			if ( $sitemap_exists ) {
 				self::delete_sitemap_by_id( $sitemap_id );
@@ -472,8 +472,8 @@ class Metro_Sitemap {
 		$xml = new SimpleXMLElement( $namespace_str );
 
 		$url_count = 0;
-		foreach ( $posts as $post ) {
-			$GLOBALS['post'] = get_post( $post );
+		foreach ( $posts_ids as $post_id ) {
+			$GLOBALS['post'] = get_post( $post_id );
 			setup_postdata( $GLOBALS['post'] );
 
 			if ( apply_filters( 'msm_sitemap_skip_post', false ) )

--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -398,7 +398,7 @@ class Metro_Sitemap {
 		$end_date = $sitemap_date . ' 23:59:59';
 		$post_types_in = self::get_supported_post_types_in();
 
-		return $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_status = 'publish' AND post_date >= %s AND post_date <= %s AND post_type IN ( {$post_types_in} ) ORDER BY post_date LIMIT %d", $start_date, $end_date, $limit ) );
+		return $wpdb->get_col( $wpdb->prepare( "SELECT * FROM $wpdb->posts WHERE post_status = 'publish' AND post_date >= %s AND post_date <= %s AND post_type IN ( {$post_types_in} ) ORDER BY post_date LIMIT %d", $start_date, $end_date, $limit ) );
 	}
 
 	/**
@@ -431,9 +431,9 @@ class Metro_Sitemap {
 		}
 
 		$per_page = apply_filters( 'msm_sitemap_entry_posts_per_page', self::DEFAULT_POSTS_PER_SITEMAP_PAGE );
-		$post_ids = self::get_post_ids_for_date( $sitemap_date, $per_page );
+		$posts = self::get_post_ids_for_date( $sitemap_date, $per_page );
 
-		if ( empty( $post_ids ) ) {
+		if ( empty( $posts ) ) {
 			// If no entries - delete the whole sitemap post
 			if ( $sitemap_exists ) {
 				self::delete_sitemap_by_id( $sitemap_id );
@@ -468,8 +468,8 @@ class Metro_Sitemap {
 		$xml = new SimpleXMLElement( $namespace_str );
 
 		$url_count = 0;
-		foreach ( $post_ids as $post_id ) {
-			$GLOBALS['post'] = get_post( $post_id );
+		foreach ( $post_ids as $post ) {
+			$GLOBALS['post'] = get_post( $post );
 			setup_postdata( $GLOBALS['post'] );
 
 			if ( apply_filters( 'msm_sitemap_skip_post', false ) )

--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -441,16 +441,6 @@ class Metro_Sitemap {
 			return;
 		}
 
-		// We need to get a WP_Query object for back-compat as we run a Loop when building
-		$query = new WP_Query( array(
-			'post__in' => $post_ids,
-			'post_type' => self::get_supported_post_types(),
-			'no_found_rows' => true,
-			'posts_per_page' => $per_page,
-			'ignore_sticky_posts' => true,
-			'post_status' => 'publish',
-		) );
-
 		$total_url_count = self::get_total_indexed_url_count();
 
 		// For migration: in case the previous version used an array for this option
@@ -478,8 +468,9 @@ class Metro_Sitemap {
 		$xml = new SimpleXMLElement( $namespace_str );
 
 		$url_count = 0;
-		while ( $query->have_posts() ) {
-			$query->the_post();
+		foreach ( $post_ids as $post_id ) {
+			$GLOBALS['post'] = get_post( $post_id );
+			setup_postdata( $GLOBALS['post'] );
 
 			if ( apply_filters( 'msm_sitemap_skip_post', false ) )
 				continue;

--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -398,11 +398,11 @@ class Metro_Sitemap {
 		$end_date = $sitemap_date . ' 23:59:59';
 		$post_types_in = self::get_supported_post_types_in();
 
-		$posts = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $wpdb->posts WHERE post_status = 'publish' AND post_date >= %s AND post_date <= %s AND post_type IN ( {$post_types_in} ) ORDER BY post_date LIMIT %d", $start_date, $end_date, $limit ) );
+		$posts = $wpdb->get_results( $wpdb->prepare( "SELECT ID, post_date FROM $wpdb->posts WHERE post_status = 'publish' AND post_date >= %s AND post_date <= %s AND post_type IN ( {$post_types_in} ) ORDER BY post_date LIMIT %d", $start_date, $end_date, $limit ) );
 
 		usort( $posts, array( __CLASS__ , 'order_by_post_date' ) );
 
-		return $posts;
+		return wp_list_pluck( $posts, 'ID' );
 	}
 
 	/**

--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -402,7 +402,9 @@ class Metro_Sitemap {
 
 		usort( $posts, array( __CLASS__ , 'order_by_post_date' ) );
 
-		return wp_list_pluck( $posts, 'ID' );
+		$post_ids = wp_list_pluck( $posts, 'ID' );
+
+		return array_map( 'intval', $post_ids );
 	}
 
 	/**
@@ -435,9 +437,9 @@ class Metro_Sitemap {
 		}
 
 		$per_page = apply_filters( 'msm_sitemap_entry_posts_per_page', self::DEFAULT_POSTS_PER_SITEMAP_PAGE );
-		$posts_ids = self::get_post_ids_for_date( $sitemap_date, $per_page );
+		$post_ids = self::get_post_ids_for_date( $sitemap_date, $per_page );
 
-		if ( empty( $posts_ids ) ) {
+		if ( empty( $post_ids ) ) {
 			// If no entries - delete the whole sitemap post
 			if ( $sitemap_exists ) {
 				self::delete_sitemap_by_id( $sitemap_id );
@@ -472,7 +474,7 @@ class Metro_Sitemap {
 		$xml = new SimpleXMLElement( $namespace_str );
 
 		$url_count = 0;
-		foreach ( $posts_ids as $post_id ) {
+		foreach ( $post_ids as $post_id ) {
 			$GLOBALS['post'] = get_post( $post_id );
 			setup_postdata( $GLOBALS['post'] );
 

--- a/tests/test-sitemap-creation.php
+++ b/tests/test-sitemap-creation.php
@@ -87,6 +87,8 @@ class WP_Test_Sitemap_Creation extends WP_UnitTestCase {
 			$this->assertNotEmpty( $xml_struct->url );
 			$this->assertNotEmpty( $xml_struct->url->loc );
 			$this->assertNotEmpty( $xml_struct->url->lastmod );
+			$this->assertNotEmpty( $xml_struct->url->changefreq );
+			$this->assertNotEmpty( $xml_struct->url->priority );
 			$this->assertContains( 'p=' . $post_id, (string) $xml_struct->url->loc );
 
 			$post = get_post( $post_id );

--- a/tests/test-sitemap-functions.php
+++ b/tests/test-sitemap-functions.php
@@ -269,7 +269,7 @@ class WP_Test_Sitemap_Functions extends WP_UnitTestCase {
 
 		$post_ids = Metro_Sitemap::get_post_ids_for_date( $sitemap_date, $limit );
 		$this->assertEquals( $expected_count, count( $post_ids ) );
-		$this->assertEquals( array_slice( $created_post_ids, 0, $limit ), $post_ids );
+		$this->assertEquals( array_slice( $created_post_ids, 0, $limit ), wp_list_pluck( $post_ids, 'ID' ) );
 
 	}
 

--- a/tests/test-sitemap-functions.php
+++ b/tests/test-sitemap-functions.php
@@ -269,7 +269,7 @@ class WP_Test_Sitemap_Functions extends WP_UnitTestCase {
 
 		$post_ids = Metro_Sitemap::get_post_ids_for_date( $sitemap_date, $limit );
 		$this->assertEquals( $expected_count, count( $post_ids ) );
-		$this->assertEquals( array_slice( $created_post_ids, 0, $limit ), wp_list_pluck( $post_ids, 'ID' ) );
+		$this->assertEquals( array_slice( $created_post_ids, 0, $limit ), $post_ids );
 
 	}
 


### PR DESCRIPTION
Testing the build on cold caches shows performance improvement of ~33%.

I have also been testing a situation in which the direct SQL query would return whole line which is then passed to `get_post()`, but it does not show any performance improvement and shows performance decrease agains this version with warm caches (eg.: rebuild due to post edit situation).