### PR TITLE
Substitute cal_days_in_month

### DIFF
--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -99,8 +99,7 @@ class Metro_Sitemap_CLI extends WP_CLI_Command {
 
 		WP_CLI::line( sprintf( 'Generating sitemap for %s-%s', $year, $month ) );
 
-		// Calculate actual number of days in the month since we don't have cal_days_in_month available
-		$max_days = 31;
+		$max_days = $this->cal_days_in_month( $month, $year );
 
 		if ( date( 'Y' ) == $year && date( 'n' ) == $month ) {
 			$max_days = date( 'j' );
@@ -237,5 +236,23 @@ class Metro_Sitemap_CLI extends WP_CLI_Command {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Return max number of days in a month of a year.
+	 *
+	 * Uses cal_days_in_month if available, if not, takes advantage of `date( 't' )` and `mktime`.
+	 *
+	 * @param int $month Month
+	 * @param int $year Year
+	 *
+	 * @return int Number of days in a month of a year.
+	 */
+	private function cal_days_in_month( $month, $year ) {
+		if ( function_exists( 'cal_days_in_month' ) ) {
+			return cal_days_in_month( CAL_GREGORIAN, $month, $year );
+		}
+		// Calculate actual number of days in the month since we don't have cal_days_in_month available
+		return date( 't', mktime( 0, 0, 0, $month, 1, $year ) );
 	}
 }

--- a/tests/includes/mock-wp-cli.php
+++ b/tests/includes/mock-wp-cli.php
@@ -1,0 +1,25 @@
+<?php
+
+if ( false === class_exists( 'WP_CLI' ) ) {
+	class WP_CLI {
+		public function __call( $method, $params ) {
+			return;
+		}
+
+		public static function __callStatic( $method, $params ) {
+			return;
+		}
+	}
+}
+
+if ( false === class_exists( 'WP_CLI_Command' ) ) {
+	class WP_CLI_Command {
+		public function __call( $method, $params ) {
+			return;
+		}
+
+		public static function __callStatic( $method, $params ) {
+			return;
+		}
+	}
+}

--- a/tests/test-sitemap-cli.php
+++ b/tests/test-sitemap-cli.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * WP_Test_Sitemap_CLI
+ *
+ * @package Metro_Sitemap/unit_tests
+ */
+
+require_once( 'msm-sitemap-test.php' );
+
+require_once( dirname( __FILE__ ) . '/includes/mock-wp-cli.php' );
+require_once( dirname( __FILE__ ) . '/../includes/wp-cli.php' );
+
+/**
+ * Unit Tests to validate CLI command
+ *
+ * @author bcampeau
+ */
+class WP_Test_Sitemap_CLI extends WP_UnitTestCase {
+
+	/**
+	 * Call protected/private method of a class.
+	 *
+	 * @param object $object    Instantiated object that we will run method on.
+	 * @param string $method_name Method name to call.
+	 * @param array  $parameters Array of parameters to pass into method.
+	 *
+	 * @return mixed Method return.
+	 */
+	public function invoke_method( &$object, $method_name, array $parameters = array() ) {
+		$reflection = new \ReflectionClass( get_class( $object ) );
+		$method = $reflection->getMethod( $method_name );
+		$method->setAccessible( true );
+
+		return $method->invokeArgs( $object, $parameters );
+	}
+
+	/**
+	 * Provides test data for calculating maximum number of days in year.
+	 *
+	 * @return array
+	 */
+	public function dates_provider() {
+		return array(
+			array( 2, 2016, 29 ),
+			array( 2, 2017, 28 ),
+			array( 1, 2015, 31 ),
+			array( 3, 2014, 31 ),
+			array( 4, 2012, 30 ),
+			array( 12, 2011, 31 ),
+			array( 11, 2010, 30 ),
+		);
+	}
+
+	/**
+	 * Test that robots.txt has sitemap indexes for all years when sitemaps by year are enabled
+	 *
+	 * @dataProvider dates_provider
+	 * @param $month Month in a year.
+	 * @param $year Year.
+	 * @param $expected Expected number of days in given month/year.
+	 */
+	public function test_cal_days_in_month( $month, $year, $expected ) {
+
+		$cli = new Metro_Sitemap_CLI();
+
+		$max_days = $this->invoke_method( $cli, 'cal_days_in_month', array( $month, $year ) );
+
+		// Check that we've indexed the proper total number of URLs.
+		$this->assertEquals( $expected, $max_days );
+	}
+}
+


### PR DESCRIPTION
This PR adds `Metro_Sitemap_CLI::cal_days_in_month` method, which either uses `cal_days_in_month` function if PHP Calendar extension is installed or calculates the max number of days in month using the `date( 't' )` and `mktime` functions.

It also adds first unit tests for the `Metro_Sitemap_CLI` class, currently only covering the new `cal_days_in_month`. The `WP_CLI` and `WP_CLI_Command` classes are currently only mocked, as they are really not needed for existing tests.