### PR TITLE
Remove cron override code for VIP Go

### DIFF
--- a/vipgo-helper.php
+++ b/vipgo-helper.php
@@ -1,33 +1,3 @@
 <?php
 
-// Add the update cron, since this is necessary for ongoing updates
-add_action( 'msm_update_sitemap_for_year_month_date', 'vipgo_schedule_sitemap_update_for_year_month_date', 10, 2 );
-add_action( 'msm_vipgo_cron_generate_sitemap_for_year_month_day', 'vipgo_generate_sitemap_for_year_month_day' );
-
-function vipgo_schedule_sitemap_update_for_year_month_date( $date, $time ) {
-	list( $year, $month, $day ) = $date;
-
-	wp_schedule_single_event(
-		$time,
-		'msm_vipgo_cron_generate_sitemap_for_year_month_day',
-		array(
-			array(
-				'year' => (int) $year,
-				'month' => (int) $month,
-				'day' => (int) $day,
-			),
-		)
-	);
-}
-
-function vipgo_generate_sitemap_for_year_month_day( $args ) {
-	$year = $args['year'];
-	$month = $args['month'];
-	$day = $args['day'];
-	$date_stamp = Metro_Sitemap::get_date_stamp( $year, $month, $day );
-	if ( Metro_Sitemap::date_range_has_posts( $date_stamp, $date_stamp ) ) {
-		Metro_Sitemap::generate_sitemap_for_date( $date_stamp );
-	} else {
-		Metro_Sitemap::delete_sitemap_for_date( $date_stamp );
-	}
-}
+// VIP Go-specific code can go here...


### PR DESCRIPTION
In #131, we restored the cron builder for VIP Go sites, but did not remove the related overrides, which means that we end up creating multiple events for each day which do the same thing; e.g.

```
| msm_cron_generate_sitemap_for_year_month           |           4 |
| msm_cron_generate_sitemap_for_year_month_day       |        5821 |
| msm_cron_update_sitemap                            |           1 |
| msm_vipgo_cron_generate_sitemap_for_year_month_day |        1183 |
```