### PR TITLE
Update the plugin version and the stable tag

### DIFF
--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -3,8 +3,8 @@
 Plugin Name: Metro Sitemap
 Description: Comprehensive sitemaps for your WordPress site. Joint collaboration between Metro.co.uk, MAKE, Alley Interactive, and WordPress.com VIP.
 Author: Artur Synowiec, Paul Kevan, and others
-Version: 1.3
-Stable tag: 1.3
+Version: 1.4
+Stable tag: 1.4
 License: GPLv2
 */
 


### PR DESCRIPTION
The plugin version and the stable tag were left unchanged after the [version bump to 1.4](https://github.com/Automattic/msm-sitemap/releases/tag/1.4)