### PR TITLE
Add filter to limit the sitemap date range

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,10 @@ Second, if you are filtering the root sitemap, which displays the URLs to the in
 
 ## Filter Sitemap Index
 
-Use the `msm_sitemap_index` filter to exclude day sitemaps from the index.
+Use the `msm_sitemap_index` filter to exclude daily sitemaps from the index based on date.
 
 ```
-TODO: Add an example.
+add_filter( 'msm_sitemap_index', function( $sitemaps ) {
+	return array_filter( $sitemaps, function( $date ) { return '2017-09-09' < $date; } );
+});
 ```

--- a/README.md
+++ b/README.md
@@ -60,3 +60,12 @@ add_filter( 'msm_sitemap_entry', 'example_filter_msm_sitemap_entry', 10, 1 );
 ```
 
 Second, if you are filtering the root sitemap, which displays the URLs to the individual sitemaps by date, you will need to filter the `home_url` directly. There is no plugin-specific hook to filter the URLs on the root sitemap.
+
+
+## Filter Sitemap Index
+
+Use the `msm_sitemap_index` filter to exclude day sitemaps from the index.
+
+```
+TODO: Add an example.
+```

--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -674,7 +674,7 @@ class Metro_Sitemap {
 		// Sometimes duplicate sitemaps exist, lets make sure so they are not output
 		$sitemaps = array_unique( $sitemaps );
 
-		// Allow excluding daily sitemaps from the index.
+		// Filter daily sitemaps from the index by date.
 		$sitemaps = apply_filters( 'msm_sitemap_index', $sitemaps, $year );
 
 		$xml = new SimpleXMLElement( $xml_prefix . '<sitemapindex xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></sitemapindex>' );

--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -674,7 +674,19 @@ class Metro_Sitemap {
 		// Sometimes duplicate sitemaps exist, lets make sure so they are not output
 		$sitemaps = array_unique( $sitemaps );
 
-		// Filter daily sitemaps from the index by date.
+		/**
+		 * Filter daily sitemaps from the index by date.
+		 *
+		 * Expects an array of dates in MySQL DATETIME format [ Y-m-d H:i:s ].
+		 *
+		 * Since adding dates that do not have posts is pointless, this filter is primarily intended for removing
+		 * dates before or after a specific date or possibly targeting specific dates to exclude.
+		 *
+		 * @since 1.4.0
+		 *
+		 * @param array  $sitemaps Array of dates in MySQL DATETIME format [ Y-m-d H:i:s ].
+		 * @param string $year     Year that sitemap is being generated for.
+		 */
 		$sitemaps = apply_filters( 'msm_sitemap_index', $sitemaps, $year );
 
 		$xml = new SimpleXMLElement( $xml_prefix . '<sitemapindex xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></sitemapindex>' );

--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -674,6 +674,9 @@ class Metro_Sitemap {
 		// Sometimes duplicate sitemaps exist, lets make sure so they are not output
 		$sitemaps = array_unique( $sitemaps );
 
+		// Allow excluding daily sitemaps from the index.
+		$sitemaps = apply_filters( 'msm_sitemap_index', $sitemaps, $year );
+
 		$xml = new SimpleXMLElement( $xml_prefix . '<sitemapindex xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></sitemapindex>' );
 		foreach ( $sitemaps as $sitemap_date ) {
 			$sitemap = $xml->addChild( 'sitemap' );

--- a/tests/test-sitemap-filter.php
+++ b/tests/test-sitemap-filter.php
@@ -45,5 +45,16 @@ class WP_Test_Sitemap_Filter extends WP_UnitTestCase {
 		
 	}
 
+	/**
+	 * Verify that msm_sitemap_index filter runs when build_root_sitemap_xml is called.
+	 */
+	function test_msm_sitemap_index_filter_ran() {
+		$ran = false;
+
+		add_filter( 'msm_sitemap_index', function() use ( &$ran ) { $ran = true; return []; } );
+		Metro_Sitemap::build_root_sitemap_xml();
+
+		$this->assertTrue( $ran );
+	}
 }
 


### PR DESCRIPTION
Fixes #146.

- Introduce the `msm_sitemap_index` filter which allows removing daily sitemaps from the root sitemap index.