### PR TITLE
Fix slow query

### DIFF
--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -327,12 +327,11 @@ class Metro_Sitemap {
 	public static function get_post_year_range() {
 		global $wpdb;
 
-		$oldest_post_date_gmt = $wpdb->get_var( "SELECT post_date FROM $wpdb->posts WHERE post_status = 'publish' ORDER BY post_date ASC LIMIT 1" );
+		$oldest_post_date_year = $wpdb->get_var( "SELECT DISTINCT YEAR(post_date) as year FROM $wpdb->posts WHERE post_status = 'publish' ORDER BY year ASC LIMIT 1" );
 
-		if ( null !== $oldest_post_date_gmt ) {
-			$oldest_post_year = date( 'Y', strtotime( $oldest_post_date_gmt ) );
+		if ( null !== $oldest_post_date_year ) {
 			$current_year = date( 'Y' );
-			return range( $oldest_post_year, $current_year );
+			return range( (int) $oldest_post_date_year, $current_year );
 		}
 
 		return array();


### PR DESCRIPTION
On sites that have millions of posts in their wp_posts table, the old query can take A VERY LONG TIME.

Switching it to this, and just returning the year from SQL speeds it up.  In my testing, this can be up to 500% faster.