### PR TITLE
Disables WordPress 5.5 Sitemaps

### DIFF
--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -38,6 +38,9 @@ class Metro_Sitemap {
 		add_action( 'init', array( __CLASS__, 'create_post_type' ) );
 		add_filter( 'posts_pre_query', array( __CLASS__, 'disable_main_query_for_sitemap_xml' ), 10, 2 );
 		add_filter( 'template_include', array( __CLASS__, 'load_sitemap_template' ) );
+		
+		// Disable WordPress 5.5-era sitemaps.
+		add_filter( 'wp_sitemaps_is_enabled', '__return_false' );
 
 		// By default, we use wp-cron to help generate the full sitemap.
 		// However, this will let us override it, if necessary, like on WP.com

--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -40,7 +40,7 @@ class Metro_Sitemap {
 		add_filter( 'template_include', array( __CLASS__, 'load_sitemap_template' ) );
 		
 		// Disable WordPress 5.5-era sitemaps.
-		add_filter( 'wp_sitemaps_is_enabled', '__return_false' );
+		add_filter( 'wp_sitemaps_enabled', '__return_false' );
 
 		// By default, we use wp-cron to help generate the full sitemap.
 		// However, this will let us override it, if necessary, like on WP.com


### PR DESCRIPTION
WordPress 5.5 is adding native sitemaps (https://core.trac.wordpress.org/changeset/48072). 

This PR disables them to prevent confusion and duplication.