### PR TITLE
Temporary workaround for sitemaps returning 404

### DIFF
--- a/vipgo-helper.php
+++ b/vipgo-helper.php
@@ -1,3 +1,9 @@
 <?php
 
 // VIP Go-specific code can go here...
+
+// Temporary workaround for sitemaps returning 404 (https://core.trac.wordpress.org/ticket/51136)
+add_action('init', function() {
+        global $wp_sitemaps;
+        remove_action( 'template_redirect', array( $wp_sitemaps, 'render_sitemaps' ) );
+}, 100 );


### PR DESCRIPTION
After the 5.5 release, sitemaps were added to the core. Since both Core and msm-sitemap are using the `sitemap` rewrite parameter, a Core bug is making all the sitemap requests return 404, despite sending the correct XML.

I'm adding this on `vipgo-helper.php` as this is intended as a temporary workaround, but happy to move it to `msm-sitemap.php` if needed.

See https://core.trac.wordpress.org/ticket/51136