### PR TITLE
Add status header to template to overload core 404

### DIFF
--- a/templates/full-sitemaps.php
+++ b/templates/full-sitemaps.php
@@ -25,6 +25,7 @@ if ( $build_xml === false ) {
 		array ( 'response' => 404 )
 	);
 }
+status_header( 200 );
 header( 'Content-type: application/xml; charset=UTF-8' );
 echo $build_xml;
 ?>


### PR DESCRIPTION
Core introduced sitemaps in 5.5 and a workaround for the 404 bug was introduced here in #161 

Instead of relying on a workaround, however, `status_header` will overload any previously set status_header value. As we're already defining headers in the template, it seems like a natural location to add a one line fix for this problem.