### PR TITLE
Add msm_pre_get_last_modified_posts filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,19 @@ add_filter( 'msm_sitemap_index', function( $sitemaps ) {
     } );
 } );
 ```
+
+## Filter Sitemap Index
+
+Use the `msm_pre_get_last_modified_posts` filter to customize the query that gets the last modified posts.
+
+On large sites, this filter could be leveraged to enhance query efficiency by avoiding scanning older posts that don't get updated frequently and making better use of the `type_status_date` index.
+
+```
+function ( $query, $post_types_in, $date ) {
+    global $wpdb;
+
+    $query = $wpdb->prepare( "SELECT ID, post_date FROM $wpdb->posts WHERE post_type IN ( {$post_types_in} ) AND post_status = 'publish' AND post_date >= DATE_SUB(NOW(), INTERVAL 3 MONTH) AND post_modified_gmt >= %s LIMIT 1000", $date );
+
+    return $query;
+};
+```

--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -615,7 +615,19 @@ class Metro_Sitemap {
 
 		$post_types_in = self::get_supported_post_types_in();
 
-		$modified_posts = $wpdb->get_results( $wpdb->prepare( "SELECT ID, post_date FROM $wpdb->posts WHERE post_type IN ( {$post_types_in} ) AND post_modified_gmt >= %s LIMIT 1000", $date ) );
+		$query = $wpdb->prepare( "SELECT ID, post_date FROM $wpdb->posts WHERE post_type IN ( {$post_types_in} ) AND post_modified_gmt >= %s LIMIT 1000", $date );
+
+		/**
+		 * Filter the query used to get the last modified posts.
+		 * 
+		 * @param string|null $query The query to use to get the last modified posts.
+		 * @param string $post_types_in A comma-separated list of post types to include in the query.
+		 * @param string $date The date to use as the cutoff for the query.
+		 */
+		$query = apply_filters( 'msm_pre_get_last_modified_posts', $query, $post_types_in, $date );
+
+		$modified_posts = $wpdb->get_results( $query );
+
 		return $modified_posts;
 	}
 

--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -619,10 +619,11 @@ class Metro_Sitemap {
 
 		/**
 		 * Filter the query used to get the last modified posts.
+		 * $wpdb->prepare() should be used for security if a new replacement query is created in the callback.
 		 * 
-		 * @param string|null $query The query to use to get the last modified posts.
+		 * @param string $query         The query to use to get the last modified posts.
 		 * @param string $post_types_in A comma-separated list of post types to include in the query.
-		 * @param string $date The date to use as the cutoff for the query.
+		 * @param string $date          The date to use as the cutoff for the query.
 		 */
 		$query = apply_filters( 'msm_pre_get_last_modified_posts', $query, $post_types_in, $date );
 


### PR DESCRIPTION
Adds a filter for the query in `Metro_Sitemap::get_last_modified_posts()`.

Tackles: https://github.com/Automattic/msm-sitemap/issues/155