### PR TITLE
Add Post ID to msm_sitmap_skip_posts

### DIFF
--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -507,8 +507,9 @@ class Metro_Sitemap {
 			$GLOBALS['post'] = get_post( $post_id );
 			setup_postdata( $GLOBALS['post'] );
 
-			if ( apply_filters( 'msm_sitemap_skip_post', false ) )
+			if ( apply_filters( 'msm_sitemap_skip_post', false, $post_id ) ) {
 				continue;
+			}
 
 			$url = $xml->addChild( 'url' );
 			$url->addChild( 'loc', esc_url( get_permalink() ) );


### PR DESCRIPTION
This PR adds `$post_id` to the `msm_sitmap_skip_posts` filter. Doing so allows for posts to be excluded by using the filter directly.

Note: this is a backward incompatible change, as it adds a second argument to the filter

Fixes #183