### PR TITLE
Install SVN before checking out tests

### DIFF
--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -26,6 +26,11 @@ jobs:
           coverage: none
           tools: cs2pr
 
+      - name: Install SVN
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y subversion
+
       # Show PHP lint violations inline in the file diff.
       # @link https://github.com/marketplace/actions/xmllint-problem-matcher
       - name: Register PHP lint violations to appear as file diff comments

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -25,6 +25,9 @@ download() {
     fi
 }
 
+sudo apt-get update
+sudo apt-get install -y subversion
+
 if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+\-(beta|RC)[0-9]+$ ]]; then
 	WP_BRANCH=${WP_VERSION%\-*}
 	WP_TESTS_TAG="branches/$WP_BRANCH"
@@ -179,4 +182,3 @@ install_db() {
 install_wp
 install_test_suite
 install_db
-


### PR DESCRIPTION
Similar to this: https://github.com/WordPress/five-for-the-future/issues/337, we use SVN to checkout the tests. Need to ensure it is loaded before trying tests.