### PR TITLE
fix: Enhance tooltip for indexed URLs with pluralization support

### DIFF
--- a/js/msm-sitemap-admin.js
+++ b/js/msm-sitemap-admin.js
@@ -124,9 +124,16 @@ jQuery( document ).ready( function() {
 
 				// Get and format the data values
 				var x = item.series.xaxis.tickFormatter( item.datapoint[0], item.series.xaxis );
-				var y = item.series.yaxis.tickFormatter( item.datapoint[1], item.series.yaxis );
+				var count = item.datapoint[1];
+				var y = item.series.yaxis.tickFormatter( count, item.series.yaxis );
 
 				show_tooltip( item.pageX, item.pageY, x + ': ' + y );
+
+				// Pluralize the label using data attributes for i18n
+				var label = count === 1
+					? jQuery('#tooltip .url-label').data('singular')
+					: jQuery('#tooltip .url-label').data('plural');
+				jQuery('#tooltip .url-label').text(label);
 			}
 		} else {
 			jQuery( '#tooltip' ).stop();

--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -215,7 +215,13 @@ class Metro_Sitemap {
 			<?php endforeach; ?>
 		</form>
 		</div>
-		<div id="tooltip"><strong class="content"></strong> <?php esc_html_e( 'indexed urls', 'msm-sitemap' ); ?></div>
+		<div id="tooltip">
+			<strong class="content"></strong>
+				<span class="url-label"
+					data-singular="<?php esc_attr_e( 'indexed URL', 'msm-sitemap' ); ?>"
+					data-plural="<?php esc_attr_e( 'indexed URLs', 'msm-sitemap' ); ?>"
+				><?php esc_html_e( 'indexed URLs', 'msm-sitemap' ); ?></span>
+		</div>
 		<?php
 	}
 


### PR DESCRIPTION
- Updated the tooltip in the admin interface to include a span element for better i18n support.
- Added logic to pluralize the label for indexed URLs based on the count, improving user experience and localization. Preivously, the tooltip could say "1 index URLs".