### PR TITLE
feat: Add filters for sitemap index XML customization

### DIFF
--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -788,7 +788,30 @@ class Metro_Sitemap {
 			$sitemap = $xml->addChild( 'sitemap' );
 			$sitemap->loc = self::build_sitemap_url( $sitemap_date ); // manually set the child instead of addChild to prevent "unterminated entity reference" warnings due to encoded ampersands http://stackoverflow.com/a/555039/169478
 		}
-		return $xml->asXML();
+		$xml_string = $xml->asXML();
+
+		/**
+		 * Filter the XML to append to the sitemap index before the closing tag.
+		 *
+		 * Useful for adding in extra sitemaps to the index.
+		 *
+		 * @param string   $appended_xml The XML to append. Default empty string.
+		 * @param int|bool $year         The year for which the sitemap index is being generated, or false for all years.
+		 * @param array    $sitemaps     The sitemaps to be included in the index.
+		 */
+		$appended = apply_filters( 'msm_sitemap_index_appended_xml', '', $year, $sitemaps );
+		$xml_string = str_replace( '</sitemapindex>', $appended . '</sitemapindex>', $xml_string );
+
+		/**
+		 * Filter the whole generated sitemap index XML before output.
+		 *
+		 * @param string   $xml_string The sitemap index XML.
+		 * @param int|bool $year       The year for which the sitemap index is being generated, or false for all years.
+		 * @param array    $sitemaps   The sitemaps to be included in the index.
+		 */
+		$xml_string = apply_filters( 'msm_sitemap_index_xml', $xml_string, $year, $sitemaps );
+
+		return $xml_string;
 	}
 
 	/**

--- a/tests/FiltersTest.php
+++ b/tests/FiltersTest.php
@@ -75,5 +75,71 @@ class FiltersTest extends TestCase {
 
 		remove_all_filters( 'msm_sitemap_pre_get_post_year_range' );
 	}
+
+	/**
+	 * Verify that msm_sitemap_index_appended_xml filter can append XML and receives correct arguments.
+	 */
+	public function test_msm_sitemap_index_appended_xml_filter(): void
+	{
+		// Create a post and build sitemaps to ensure there is at least one sitemap.
+		$this->add_a_post_for_today();
+		$this->build_sitemaps();
+
+		$called_args = null;
+		$append_xml = '<sitemap><loc>https://example.com/custom.xml</loc></sitemap>';
+
+		add_filter(
+			'msm_sitemap_index_appended_xml',
+			function( $appended_xml, $year, $sitemaps ) use ( $append_xml, &$called_args ) {
+				$called_args = [ $appended_xml, $year, $sitemaps ];
+				return $append_xml;
+			},
+			10,
+			3
+		);
+
+		$xml = Metro_Sitemap::build_root_sitemap_xml();
+		$this->assertStringContainsString( $append_xml, $xml );
+		$this->assertIsArray( $called_args );
+		$this->assertEquals( '', $called_args[0] );
+		$this->assertFalse( $called_args[1] );
+		$this->assertIsArray( $called_args[2] );
+		$this->assertNotEmpty( $called_args[2] );
+
+		remove_all_filters( 'msm_sitemap_index_appended_xml' );
+	}
+
+	/**
+	 * Verify that msm_sitemap_index_xml filter can modify the final XML and receives correct arguments.
+	 */
+	public function test_msm_sitemap_index_xml_filter(): void
+	{
+		// Create a post and build sitemaps to ensure there is at least one sitemap.
+		$this->add_a_post_for_today();
+		$this->build_sitemaps();
+
+		$called_args = null;
+		$replacement_xml = '<?xml version="1.0"?><sitemapindex><sitemap><loc>https://example.com/override.xml</loc></sitemap></sitemapindex>';
+
+		add_filter(
+			'msm_sitemap_index_xml',
+			function( $xml_string, $year, $sitemaps ) use ( $replacement_xml, &$called_args ) {
+				$called_args = [ $xml_string, $year, $sitemaps ];
+				return $replacement_xml;
+			},
+			10,
+			3
+		);
+
+		$xml = Metro_Sitemap::build_root_sitemap_xml();
+		$this->assertEquals( $replacement_xml, $xml );
+		$this->assertIsArray( $called_args );
+		$this->assertStringContainsString( '<sitemapindex', $called_args[0] );
+		$this->assertFalse( $called_args[1] );
+		$this->assertIsArray( $called_args[2] );
+		$this->assertNotEmpty( $called_args[2] );
+
+		remove_all_filters( 'msm_sitemap_index_xml' );
+	}
 }
 


### PR DESCRIPTION
- Introduced two filters: `msm_sitemap_index_appended_xml` to allow appending additional XML before the closing tag, and `msm_sitemap_index_xml` to filter the entire generated sitemap index XML.
- This enhancement provides users with greater flexibility in customizing their sitemap outputs.
- Includes tests.

Closes #143.