### PR TITLE
Add custom post permalink handling for msm_sitemap posts

### DIFF
--- a/includes/Permalinks.php
+++ b/includes/Permalinks.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Permalinks handler for msm_sitemap posts.
+ *
+ * Ensures that get_permalink() and related tooling return the correct public-facing URL for each sitemap.
+ * Handles both daily and year-based index URLs.
+ *
+ * @see https://github.com/Automattic/msm-sitemap/issues/170
+ */
+declare(strict_types=1);
+
+namespace Automattic\MSM_Sitemap;
+
+class Permalinks {
+    /**
+     * Register the permalink filter.
+     */
+    public static function register(): void {
+        add_filter( 'post_type_link', [ __CLASS__, 'filter_post_type_link' ], 10, 2 );
+    }
+
+    /**
+     * Filter the permalink for msm_sitemap posts to match the actual sitemap endpoint.
+     *
+     * @param string  $permalink The default permalink.
+     * @param \WP_Post $post      The post object.
+     * @return string The corrected sitemap URL.
+     */
+    public static function filter_post_type_link( string $permalink, \WP_Post $post ): string {
+        if ( $post->post_type !== 'msm_sitemap' ) {
+            return $permalink;
+        }
+        
+        $date = $post->post_name; // e.g., '2022-11-11' or '2022'
+        
+        // Check if we should index by year (via filter).
+        $index_by_year = apply_filters( 'msm_sitemap_index_by_year', false );
+
+        if ( $index_by_year && preg_match( '/^(\d{4})$/', $date, $matches ) ) {
+            $year = $matches[1];
+            return home_url( "/sitemap-$year.xml" );
+        }
+        if ( preg_match( '/^(\d{4})-(\d{2})-(\d{2})$/', $date, $matches ) ) {
+            $year  = $matches[1];
+            $month = $matches[2];
+            $day   = $matches[3];
+            return home_url( "/sitemap.xml?yyyy=$year&mm=$month&dd=$day" );
+        }
+        // Fallback: return the default permalink if the date format is unexpected.
+        return $permalink;
+    }
+} 

--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -985,4 +985,9 @@ class Metro_Sitemap {
 	}
 }
 
+// Register custom permalink handler for msm_sitemap posts.
+// @see https://github.com/Automattic/msm-sitemap/issues/170
+require_once __DIR__ . '/includes/Permalinks.php';
+Automattic\MSM_Sitemap\Permalinks::register();
+
 add_action( 'after_setup_theme', array( 'Metro_Sitemap', 'setup' ) );

--- a/tests/PermalinksTest.php
+++ b/tests/PermalinksTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Tests for Automattic\MSM_Sitemap\Permalinks.
+ */
+
+declare(strict_types=1);
+
+namespace Automattic\MSM_Sitemap\Tests\Includes;
+
+use Automattic\MSM_Sitemap\Permalinks;
+use PHPUnit\Framework\TestCase;
+
+class PermalinksTest extends TestCase {
+    /**
+     * @var string
+     */
+    private $site_url = 'http://example.org';
+
+    protected function setUp(): void {
+        parent::setUp();
+        // Mock home_url() globally for these tests.
+        if ( ! function_exists( 'home_url' ) ) {
+            eval('function home_url($path = "") { return "http://example.org" . $path; }');
+        }
+    }
+
+    /**
+     * Helper to create a WP_Post-like object.
+     */
+    private function make_post( string $post_type, string $post_name ): \WP_Post {
+        $post_array = [
+            'ID'        => rand(1, 10000),
+            'post_type' => $post_type,
+            'post_name' => $post_name,
+        ];
+        return new \WP_Post( (object) $post_array );
+    }
+
+    /**
+     * Test daily sitemap permalinks (YYYY-MM-DD).
+     */
+    public function test_daily_sitemap_permalink() {
+        $post = $this->make_post( 'msm_sitemap', '2024-07-15' );
+        // Simulate index by year = false
+        add_filter( 'msm_sitemap_index_by_year', '__return_false' );
+        $permalink = Permalinks::filter_post_type_link( 'http://irrelevant', $post );
+        $this->assertSame( $this->site_url . '/sitemap.xml?yyyy=2024&mm=07&dd=15', $permalink );
+        remove_filter( 'msm_sitemap_index_by_year', '__return_false' );
+    }
+
+    /**
+     * Test year-based sitemap permalinks (YYYY) when index by year is true.
+     */
+    public function test_year_sitemap_permalink() {
+        $post = $this->make_post( 'msm_sitemap', '2023' );
+        add_filter( 'msm_sitemap_index_by_year', '__return_true' );
+        $permalink = Permalinks::filter_post_type_link( 'http://irrelevant', $post );
+        $this->assertSame( $this->site_url . '/sitemap-2023.xml', $permalink );
+        remove_filter( 'msm_sitemap_index_by_year', '__return_true' );
+    }
+
+    /**
+     * Test fallback for invalid slugs.
+     */
+    public function test_invalid_slug_fallback() {
+        $post = $this->make_post( 'msm_sitemap', 'not-a-date' );
+        $permalink = Permalinks::filter_post_type_link( 'http://fallback', $post );
+        $this->assertSame( 'http://fallback', $permalink );
+    }
+
+    /**
+     * Test non-msm_sitemap post types are not affected.
+     */
+    public function test_non_sitemap_post_type() {
+        $post = $this->make_post( 'post', '2024-07-15' );
+        $permalink = Permalinks::filter_post_type_link( 'http://original', $post );
+        $this->assertSame( 'http://original', $permalink );
+    }
+} 


### PR DESCRIPTION
- Introduced a new Permalinks class to manage permalink structure for msm_sitemap post types.
- Implemented logic to generate daily and year-based sitemap URLs based on post names.
- Added unit tests to validate permalink generation and ensure correct behavior for various scenarios.

<img width="1690" height="350" alt="Screenshot 2025-07-15 at 15 54 13" src="https://github.com/user-attachments/assets/606d3b8c-27bc-4205-bce8-0afb1386d0aa" />


```shell
$ wp shell
wp> get_permalink(13);
=> string(56) "http://localhost:10028/sitemap.xml?yyyy=2025&mm=07&dd=13"
```

Fixes #170.