### PR TITLE
feat: Add sitemap_url to list and get CLI output

### DIFF
--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -338,9 +338,20 @@ class Metro_Sitemap_CLI extends WP_CLI_Command {
 					case 'status':
 						$row['status'] = $post->post_status;
 						break;
+					case 'sitemap_url':
+						$row['sitemap_url'] = \Metro_Sitemap::build_sitemap_url( $post->post_name );
+						break;
 				}
 			}
+			// Always add sitemap_url as last column if not already present
+			if ( ! isset( $row['sitemap_url'] ) ) {
+				$row['sitemap_url'] = \Metro_Sitemap::build_sitemap_url( $post->post_name );
+			}
 			$items[] = $row;
+		}
+		// Always add sitemap_url to fields if not present
+		if ( ! in_array( 'sitemap_url', $fields, true ) ) {
+			$fields[] = 'sitemap_url';
 		}
 		format_items( $format, $items, $fields );
 		return;
@@ -381,6 +392,7 @@ class Metro_Sitemap_CLI extends WP_CLI_Command {
 				'url_count'     => (int) get_post_meta( $post->ID, 'msm_indexed_url_count', true ),
 				'status'        => $post->post_status,
 				'last_modified' => $post->post_modified_gmt,
+				'sitemap_url'   => \Metro_Sitemap::build_sitemap_url( $post->post_name ),
 			);
 		} else {
 			$date_queries = $this->parse_date_query( $input, false );
@@ -408,10 +420,11 @@ class Metro_Sitemap_CLI extends WP_CLI_Command {
 					'url_count'     => (int) get_post_meta( $post->ID, 'msm_indexed_url_count', true ),
 					'status'        => $post->post_status,
 					'last_modified' => $post->post_modified_gmt,
+					'sitemap_url'   => \Metro_Sitemap::build_sitemap_url( $post->post_name ),
 				);
 			}
 		}
-		format_items( $format, $items, array( 'id', 'date', 'url_count', 'status', 'last_modified' ) );
+		format_items( $format, $items, array( 'id', 'date', 'url_count', 'status', 'last_modified', 'sitemap_url' ) );
 		return;
 	}
 

--- a/tests/Cli/GetTest.php
+++ b/tests/Cli/GetTest.php
@@ -135,10 +135,12 @@ final class GetTest extends \Automattic\MSM_Sitemap\Tests\TestCase {
 		);
 		$this->assertIsInt( $post_id2 );
 		update_post_meta( $post_id2, 'msm_indexed_url_count', 1 );
-		// The output should be deterministic: warning + JSON array in order [2024-07-11, 2024-07-10]
-		$expected = 
-			'[{"id":' . $post_id2 . ',"date":"2024-07-11","url_count":1,"status":"publish","last_modified":"2024-07-11 00:00:00"},' .
-			'{"id":' . $this->post_id . ',"date":"2024-07-10","url_count":1,"status":"publish","last_modified":"2024-07-10 00:00:00"}]';
+
+		$sitemap_url_partial = \Metro_Sitemap::$index_by_year ? 'sitemap-2024.xml?' : 'sitemap.xml?yyyy=2024&';
+
+		$expected =
+				'[{"id":' . $post_id2 . ',"date":"2024-07-11","url_count":1,"status":"publish","last_modified":"2024-07-11 00:00:00","sitemap_url":"http:\/\/example.org\/' . $sitemap_url_partial . 'mm=07&dd=11"},' .
+				'{"id":' . $this->post_id . ',"date":"2024-07-10","url_count":1,"status":"publish","last_modified":"2024-07-10 00:00:00","sitemap_url":"http:\/\/example.org\/' . $sitemap_url_partial . 'mm=07&dd=10"}]';
 		$this->expectOutputString( $expected );
 		$cli->get( array( '2024-07' ), array( 'format' => 'json' ) );
 		wp_delete_post( $post_id2, true );

--- a/tests/Cli/ListTest.php
+++ b/tests/Cli/ListTest.php
@@ -84,12 +84,15 @@ final class ListTest extends \Automattic\MSM_Sitemap\Tests\TestCase {
 		$cli = new Metro_Sitemap_CLI();
 
 		ob_start();
-		$cli->list( array(), array( 'all' => true ) );
+		$cli->list( array(), array( 'all' => true, 'format' => 'json' ) );
 		$output = ob_get_clean();
-
-		$this->assertStringContainsString( 'id', $output );
-		$this->assertStringContainsString( 'date', $output );
-		$this->assertStringContainsString( '2024-07-10', $output );
+		$data = json_decode( $output, true );
+		foreach ( $data as $row ) {
+			$this->assertStringContainsString( 'id', $output );
+			$this->assertStringContainsString( 'date', $output );
+			$this->assertStringContainsString( '2024-07-10', $output );
+			$this->assertStringContainsString( 'sitemap_url', $output );
+		}
 	}
 
 	/**
@@ -179,13 +182,16 @@ final class ListTest extends \Automattic\MSM_Sitemap\Tests\TestCase {
 			array(
 				'all'    => true,
 				'format' => 'json',
-			) 
+			)
 		);
 		$output = ob_get_clean();
-
-		$this->assertStringContainsString( '2024-07-10', $output );
-		$this->assertStringContainsString( '"id"', $output );
-		$this->assertStringContainsString( '"date"', $output );
+		$data = json_decode( $output, true );
+		foreach ( $data as $row ) {
+			$this->assertStringContainsString( '2024-07-10', $output );
+			$this->assertStringContainsString( '"id"', $output );
+			$this->assertStringContainsString( '"date"', $output );
+			$this->assertStringContainsString( '"sitemap_url"', $output );
+		}
 	}
 
 	/**
@@ -202,11 +208,11 @@ final class ListTest extends \Automattic\MSM_Sitemap\Tests\TestCase {
 			array(
 				'all'    => true,
 				'format' => 'csv',
-			) 
+			)
 		);
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'id,date,url_count,status', $output );
+		$this->assertStringContainsString( 'id,date,url_count,status,sitemap_url', $output );
 		$this->assertStringContainsString( '2024-07-10', $output );
 	}
 


### PR DESCRIPTION
After some playing with the new commands, I found that I wanted to be able to see where the sitemaps retrieved via `list` and `get` lived (the sitemap URL).

I've added a 'sitemap_url' field in the output for both the `list` and `get` commands. This improves the usability of the CLI by providing users with direct access to the sitemap URLs associated with their posts.