### PR TITLE
refactor: Introduce Site class

### DIFF
--- a/includes/Admin/UI.php
+++ b/includes/Admin/UI.php
@@ -8,6 +8,7 @@
 namespace Automattic\MSM_Sitemap\Admin;
 
 use Automattic\MSM_Sitemap\Cron_Service;
+use Automattic\MSM_Sitemap\Site;
 
 /**
  * Handles all admin page UI rendering
@@ -23,7 +24,7 @@ class UI {
 		}
 
 		// Check if blog is public
-		if ( ! \Metro_Sitemap::is_blog_public() ) {
+		if ( ! Site::is_public() ) {
 			self::render_private_site_message();
 			return;
 		}

--- a/includes/CronService.php
+++ b/includes/CronService.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Automattic\MSM_Sitemap;
 
+use Automattic\MSM_Sitemap\Site;
+
 /**
  * Service class for managing sitemap cron functionality.
  * 
@@ -112,7 +114,7 @@ class Cron_Service {
 	public static function get_cron_status() {
 		$is_enabled     = self::is_cron_enabled();
 		$next_scheduled = wp_next_scheduled( 'msm_cron_update_sitemap' );
-		$is_blog_public = \Metro_Sitemap::is_blog_public();
+		$is_blog_public = Site::is_public();
 		$is_generating  = (bool) get_option( 'msm_sitemap_create_in_progress' );
 		$is_halted      = (bool) get_option( 'msm_stop_processing' );
 

--- a/includes/Permalinks.php
+++ b/includes/Permalinks.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Automattic\MSM_Sitemap;
 
+use Automattic\MSM_Sitemap\Site;
+
 /**
  * Permalinks handler for msm_sitemap posts.
  *
@@ -42,13 +44,13 @@ class Permalinks {
 
 		if ( $index_by_year && preg_match( '/^(\d{4})$/', $date, $matches ) ) {
 			$year = $matches[1];
-			return home_url( "/sitemap-$year.xml" );
+			return Site::get_home_url( "/sitemap-$year.xml" );
 		}
 		if ( preg_match( '/^(\d{4})-(\d{2})-(\d{2})$/', $date, $matches ) ) {
 			$year  = $matches[1];
 			$month = $matches[2];
 			$day   = $matches[3];
-			return home_url( "/sitemap.xml?yyyy=$year&mm=$month&dd=$day" );
+			return Site::get_home_url( "/sitemap.xml?yyyy=$year&mm=$month&dd=$day" );
 		}
 		// Fallback: return the default permalink if the date format is unexpected.
 		return $permalink;

--- a/includes/Site.php
+++ b/includes/Site.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Site information and configuration handler.
+ *
+ * @package Automattic\MSM_Sitemap
+ */
+
+declare(strict_types=1);
+
+namespace Automattic\MSM_Sitemap;
+
+/**
+ * Site class for handling site-related information and configuration.
+ *
+ * Provides a clean interface for accessing site settings and configuration
+ * that are relevant to sitemap generation and site visibility.
+ */
+class Site {
+
+	/**
+	 * Check if the site is public (search engines can index).
+	 *
+	 * Determines whether the site is configured to allow search engines
+	 * to index the content. This is based on the 'blog_public' option.
+	 *
+	 * @return bool True if the site is public, false otherwise.
+	 */
+	public static function is_public(): bool {
+		return ( '1' === get_option( 'blog_public' ) );
+	}
+
+	/**
+	 * Get the home URL for the site.
+	 *
+	 * Returns the home URL of the site, which is typically used for
+	 * generating sitemap URLs and other site-related links.
+	 *
+	 * @param string $path Optional. Path relative to the home URL.
+	 * @return string The home URL with optional path appended.
+	 */
+	public static function get_home_url( string $path = '' ): string {
+		return home_url( $path );
+	}
+} 

--- a/includes/StylesheetManager.php
+++ b/includes/StylesheetManager.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Automattic\MSM_Sitemap;
 
+use Automattic\MSM_Sitemap\Site;
+
 /**
  * Manages MSM-specific stylesheet modifications and references.
  *
@@ -34,7 +36,7 @@ class StylesheetManager {
 	 * @return string XSL stylesheet reference for sitemap.
 	 */
 	public static function get_sitemap_stylesheet_reference(): string {
-		return "\n" . '<?xml-stylesheet type="text/xsl" href="' . home_url( '/wp-sitemap.xsl' ) . '"?>' . "\n";
+		return "\n" . '<?xml-stylesheet type="text/xsl" href="' . Site::get_home_url( '/wp-sitemap.xsl' ) . '"?>' . "\n";
 	}
 
 	/**
@@ -43,7 +45,7 @@ class StylesheetManager {
 	 * @return string XSL stylesheet reference for sitemap index.
 	 */
 	public static function get_index_stylesheet_reference(): string {
-		return "\n" . '<?xml-stylesheet type="text/xsl" href="' . home_url( '/wp-sitemap-index.xsl' ) . '"?>' . "\n";
+		return "\n" . '<?xml-stylesheet type="text/xsl" href="' . Site::get_home_url( '/wp-sitemap-index.xsl' ) . '"?>' . "\n";
 	}
 
 	/**

--- a/includes/msm-sitemap-builder-cron.php
+++ b/includes/msm-sitemap-builder-cron.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 use Automattic\MSM_Sitemap\Cron_Service;
 
+use Automattic\MSM_Sitemap\Site;
+
 /**
  * Sitemap builder cron handler.
  */
@@ -301,7 +303,7 @@ class MSM_Sitemap_Builder_Cron {
 	 */
 	public static function find_next_day_to_process( $year, $month, $day ) {
 		$halt = (bool) get_option( 'msm_stop_processing' ) === true;
-		if ( $halt || ! Metro_Sitemap::is_blog_public() ) {
+		if ( $halt || ! Site::is_public() ) {
 			// Allow user to bail out of the current process, doesn't remove where the job got up to
 			// or If the blog became private while sitemaps were enabled, stop here.
 			delete_option( 'msm_stop_processing' );

--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -20,6 +20,11 @@
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+use Automattic\MSM_Sitemap\Site;
+
+// Include the Site class early to ensure it's available
+require_once __DIR__ . '/includes/Site.php';
+
 if ( defined( 'WP_CLI' ) && true === WP_CLI ) {
 	require __DIR__ . '/includes/wp-cli.php';
 	WP_CLI::add_command( 'msm-sitemap', 'Metro_Sitemap_CLI' );
@@ -218,10 +223,6 @@ class Metro_Sitemap {
 		return $stats;
 	}
 
-	public static function is_blog_public() {
-		return ( 1 == get_option( 'blog_public' ) );
-	}
-
 	/**
 	 * Gets the number of URLs indexed for the given sitemap.
 	 *
@@ -249,12 +250,12 @@ class Metro_Sitemap {
 			if ( self::$index_by_year ) {
 				$years = self::check_year_has_posts();
 				foreach ( $years as $year ) {
-					$output .= 'Sitemap: ' . home_url( '/sitemap-' . absint( $year ) . '.xml' ) . PHP_EOL;
+					$output .= 'Sitemap: ' . Site::get_home_url( '/sitemap-' . absint( $year ) . '.xml' ) . PHP_EOL;
 				}
 
 				$output .= PHP_EOL;
 			} else {
-				$output .= 'Sitemap: ' . home_url( '/sitemap.xml' ) . PHP_EOL . PHP_EOL;
+				$output .= 'Sitemap: ' . Site::get_home_url( '/sitemap.xml' ) . PHP_EOL . PHP_EOL;
 			}
 		}
 		return $output;
@@ -820,7 +821,7 @@ class Metro_Sitemap {
 					'mm' => date( 'm', $sitemap_time ),
 					'dd' => date( 'd', $sitemap_time ),
 				),
-				home_url( '/sitemap-' . date( 'Y', $sitemap_time ) . '.xml' )
+				Site::get_home_url( '/sitemap-' . date( 'Y', $sitemap_time ) . '.xml' )
 			);
 		} else {
 			$sitemap_url = add_query_arg(
@@ -829,7 +830,7 @@ class Metro_Sitemap {
 					'mm'   => date( 'm', $sitemap_time ),
 					'dd'   => date( 'd', $sitemap_time ),
 				),
-				home_url( '/sitemap.xml' )
+				Site::get_home_url( '/sitemap.xml' )
 			);
 		}
 

--- a/templates/full-sitemaps.php
+++ b/templates/full-sitemaps.php
@@ -1,6 +1,8 @@
 <?php
 
-if ( ! Metro_Sitemap::is_blog_public() ) {
+use Automattic\MSM_Sitemap\Site;
+
+if ( ! Site::is_public() ) {
 	wp_die(
 		__( 'Sorry, this site is not public so sitemaps are not available.', 'msm-sitemap' ),
 		__( 'Sitemap Not Available', 'msm-sitemap' ),

--- a/tests/StylesheetManagerTest.php
+++ b/tests/StylesheetManagerTest.php
@@ -18,6 +18,11 @@ use Automattic\MSM_Sitemap\Tests\TestCase;
 class StylesheetManagerTest extends TestCase {
 
 	/**
+	 * @var string
+	 */
+	private $site_url = 'http://example.org';
+
+	/**
 	 * Test that setup method registers the correct filters.
 	 */
 	public function test_setup_registers_filters(): void {
@@ -51,7 +56,7 @@ class StylesheetManagerTest extends TestCase {
 		$this->assertStringContainsString( 'type="text/xsl"', $reference );
 		$this->assertStringContainsString( 'href="', $reference );
 		$this->assertStringContainsString( '/wp-sitemap.xsl', $reference );
-		$this->assertStringContainsString( home_url(), $reference );
+		$this->assertStringContainsString( $this->site_url, $reference );
 	}
 
 	/**
@@ -64,7 +69,7 @@ class StylesheetManagerTest extends TestCase {
 		$this->assertStringContainsString( 'type="text/xsl"', $reference );
 		$this->assertStringContainsString( 'href="', $reference );
 		$this->assertStringContainsString( '/wp-sitemap-index.xsl', $reference );
-		$this->assertStringContainsString( home_url(), $reference );
+		$this->assertStringContainsString( $this->site_url, $reference );
 	}
 
 	/**
@@ -176,8 +181,8 @@ class StylesheetManagerTest extends TestCase {
 		$index_reference   = StylesheetManager::get_index_stylesheet_reference();
 
 		// Both should use the same home URL
-		$this->assertStringContainsString( home_url(), $sitemap_reference );
-		$this->assertStringContainsString( home_url(), $index_reference );
+		$this->assertStringContainsString( $this->site_url, $sitemap_reference );
+		$this->assertStringContainsString( $this->site_url, $index_reference );
 
 		// URLs should be different
 		$this->assertStringContainsString( '/wp-sitemap.xsl', $sitemap_reference );

--- a/wpcom-helper.php
+++ b/wpcom-helper.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\MSM_Sitemap\Site;
+
 add_filter( 'msm_sitemap_use_cron_builder', '__return_false', 9999 ); // On WP.com we're going to use the jobs system
 
 if ( function_exists( 'queue_async_job' ) ) {
@@ -23,7 +25,7 @@ function msm_wpcom_schedule_sitemap_update_for_year_month_date( $date, $time ) {
  * @param string $day
  */
 function msm_sitemap_wpcom_queue_cache_invalidation( $sitemap_id, $year, $month, $day ) {
-	$sitemap_url = home_url( '/sitemap.xml' );
+	$sitemap_url = Site::get_home_url( '/sitemap.xml' );
 
 	$sitemap_urls = array(
 		$sitemap_url,


### PR DESCRIPTION
Added a new Site class to centralise site-related configurations and methods.

Updated references in the sitemap generation logic to use `Site::get_home_url()` and `Site::is_public()` for better maintainability and clarity.

This change enhances the modularity of the code by moving it out of the god class.

While static methods for now, this can later be turned into instantiated objects that are injected as needed.