### PR TITLE
refactor: Update sitemap URL generation to use Site methods

### DIFF
--- a/includes/Admin/UI.php
+++ b/includes/Admin/UI.php
@@ -37,7 +37,7 @@ class UI {
 		<div class="wrap">
 			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
 			<p>
-				<a href="<?php echo esc_url( home_url( '/sitemap.xml' ) ); ?>" target="_blank" class="button button-secondary">
+				<a href="<?php echo esc_url( Site::get_sitemap_index_url() ); ?>" target="_blank" class="button button-secondary">
 					<?php esc_html_e( 'View XML Sitemap Index', 'msm-sitemap' ); ?>
 					<span class="dashicons dashicons-external" style="vertical-align: middle;"></span>
 				</a>

--- a/includes/Infrastructure/Factories/SitemapIndexEntryFactory.php
+++ b/includes/Infrastructure/Factories/SitemapIndexEntryFactory.php
@@ -11,7 +11,6 @@ namespace Automattic\MSM_Sitemap\Infrastructure\Factories;
 
 use Automattic\MSM_Sitemap\Site;
 use Automattic\MSM_Sitemap\Domain\ValueObjects\SitemapIndexEntry;
-use Metro_Sitemap;
 use InvalidArgumentException;
 
 /**
@@ -108,14 +107,15 @@ class SitemapIndexEntryFactory {
 	 */
 	private static function build_sitemap_url( string $sitemap_date ): string {
 		$sitemap_time = strtotime( $sitemap_date );
+		$year = (int) date( 'Y', $sitemap_time );
 
-		if ( Metro_Sitemap::$index_by_year ) {
+		if ( Site::is_indexed_by_year() ) {
 			$sitemap_url = add_query_arg(
 				array(
 					'mm' => date( 'm', $sitemap_time ),
 					'dd' => date( 'd', $sitemap_time ),
 				),
-				Site::get_home_url( '/sitemap-' . date( 'Y', $sitemap_time ) . '.xml' )
+				Site::get_sitemap_index_url( $year )
 			);
 		} else {
 			$sitemap_url = add_query_arg(
@@ -124,7 +124,7 @@ class SitemapIndexEntryFactory {
 					'mm'   => date( 'm', $sitemap_time ),
 					'dd'   => date( 'd', $sitemap_time ),
 				),
-				Site::get_home_url( '/sitemap.xml' )
+				Site::get_sitemap_index_url()
 			);
 		}
 

--- a/includes/Permalinks.php
+++ b/includes/Permalinks.php
@@ -39,12 +39,9 @@ class Permalinks {
 		
 		$date = $post->post_name; // e.g., '2022-11-11' or '2022'.
 		
-		// Check if we should index by year (via filter).
-		$index_by_year = apply_filters( 'msm_sitemap_index_by_year', false );
-
-		if ( $index_by_year && preg_match( '/^(\d{4})$/', $date, $matches ) ) {
-			$year = $matches[1];
-			return Site::get_home_url( "/sitemap-$year.xml" );
+		if ( Site::is_indexed_by_year() && preg_match( '/^(\d{4})$/', $date, $matches ) ) {
+			$year = (int) $matches[1];
+			return Site::get_sitemap_index_url( $year );
 		}
 		if ( preg_match( '/^(\d{4})-(\d{2})-(\d{2})$/', $date, $matches ) ) {
 			$year  = $matches[1];

--- a/includes/Site.php
+++ b/includes/Site.php
@@ -41,4 +41,26 @@ class Site {
 	public static function get_home_url( string $path = '' ): string {
 		return home_url( $path );
 	}
+
+	/**
+	 * Check if sitemaps are indexed by year.
+	 *
+	 * @return bool True if indexed by year, false otherwise.
+	 */
+	public static function is_indexed_by_year(): bool {
+		return apply_filters( 'msm_sitemap_index_by_year', false );
+	}
+
+	/**
+	 * Get the sitemap index URL based on configuration.
+	 *
+	 * @param int|null $year Optional year for year-based indexing.
+	 * @return string The complete sitemap index URL.
+	 */
+	public static function get_sitemap_index_url( ?int $year = null ): string {
+		if ( self::is_indexed_by_year() && $year ) {
+			return home_url( "/sitemap-{$year}.xml" );
+		}
+		return home_url( '/sitemap.xml' );
+	}
 } 

--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -263,15 +263,15 @@ class Metro_Sitemap {
 		if ( '1' == $public ) {
 			$output .= '# Sitemap archive' . PHP_EOL;
 
-			if ( self::$index_by_year ) {
+			if ( Site::is_indexed_by_year() ) {
 				$years = self::check_year_has_posts();
 				foreach ( $years as $year ) {
-					$output .= 'Sitemap: ' . Site::get_home_url( '/sitemap-' . absint( $year ) . '.xml' ) . PHP_EOL;
+					$output .= 'Sitemap: ' . Site::get_sitemap_index_url( (int) $year ) . PHP_EOL;
 				}
 
 				$output .= PHP_EOL;
 			} else {
-				$output .= 'Sitemap: ' . Site::get_home_url( '/sitemap.xml' ) . PHP_EOL . PHP_EOL;
+				$output .= 'Sitemap: ' . Site::get_sitemap_index_url() . PHP_EOL . PHP_EOL;
 			}
 		}
 		return $output;
@@ -301,7 +301,7 @@ class Metro_Sitemap {
 	 * @return string URL to redirect
 	 */
 	public static function disable_canonical_redirects_for_sitemap_xml( $redirect_url, $requested_url ) {
-		if ( self::$index_by_year ) {
+		if ( Site::is_indexed_by_year() ) {
 			$pattern = '|sitemap-([0-9]{4})\.xml|';
 		} else {
 			$pattern = '|sitemap\.xml|';

--- a/tests/Cli/GetTest.php
+++ b/tests/Cli/GetTest.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 namespace Automattic\MSM_Sitemap\Tests\Cli;
 
 use Metro_Sitemap_CLI;
+use Automattic\MSM_Sitemap\Site;
 
 require_once __DIR__ . '/../Includes/mock-wp-cli.php';
 require_once __DIR__ . '/../../includes/wp-cli.php';
@@ -136,7 +137,7 @@ final class GetTest extends \Automattic\MSM_Sitemap\Tests\TestCase {
 		$this->assertIsInt( $post_id2 );
 		update_post_meta( $post_id2, 'msm_indexed_url_count', 1 );
 
-		$sitemap_url_partial = \Metro_Sitemap::$index_by_year ? 'sitemap-2024.xml?' : 'sitemap.xml?yyyy=2024&';
+		$sitemap_url_partial = Site::is_indexed_by_year() ? 'sitemap-2024.xml?' : 'sitemap.xml?yyyy=2024&';
 
 		$expected =
 				'[{"id":' . $post_id2 . ',"date":"2024-07-11","url_count":1,"status":"publish","last_modified":"2024-07-11 00:00:00","sitemap_url":"http:\/\/example.org\/' . $sitemap_url_partial . 'mm=07&dd=11"},' .

--- a/tests/IndexesTest.php
+++ b/tests/IndexesTest.php
@@ -39,7 +39,8 @@ class IndexesTest extends TestCase {
 	 */
 	public function test_single_sitemap_index(): void {
 		// Turn on indexing by year
-		Metro_Sitemap::$index_by_year = false;
+		remove_filter( 'msm_sitemap_index_by_year', '__return_true' );
+		add_filter( 'msm_sitemap_index_by_year', '__return_false' );
 
 		// Check that we have a single instance of sitemap.xml in robots.txt
 		// We can't actually use the core function since it outputs headers,
@@ -55,7 +56,8 @@ class IndexesTest extends TestCase {
 	 */
 	public function test_sitemap_index_by_year(): void {
 		// Turn on indexing by year
-		Metro_Sitemap::$index_by_year = true;
+		remove_filter( 'msm_sitemap_index_by_year', '__return_false' );
+		add_filter( 'msm_sitemap_index_by_year', '__return_true' );
 
 		// Check that we have a single instance of sitemap.xml in robots.txt
 		// We can't actually use the core function since it outputs headers,

--- a/tests/RobotsTest.php
+++ b/tests/RobotsTest.php
@@ -29,7 +29,8 @@ class RobotsTest extends TestCase {
 	 * Test that a public blog with year indexing off outputs a single sitemap.
 	 */
 	public function test_public_blog_year_indexing_off_outputs_single_sitemap() {
-		Metro_Sitemap::$index_by_year = false;
+		remove_filter( 'msm_sitemap_index_by_year', '__return_true' );
+		add_filter( 'msm_sitemap_index_by_year', '__return_false' );
 		$output                       = Metro_Sitemap::robots_txt( '', '1' );
 		$this->assertStringContainsString( 'Sitemap: ', $output );
 		$this->assertStringContainsString( '/sitemap.xml', $output );
@@ -41,7 +42,8 @@ class RobotsTest extends TestCase {
 	 * Test that a public blog with year indexing on outputs a sitemap per year.
 	 */
 	public function test_public_blog_year_indexing_on_outputs_sitemap_per_year() {
-		Metro_Sitemap::$index_by_year = true;
+		remove_filter( 'msm_sitemap_index_by_year', '__return_false' );
+		add_filter( 'msm_sitemap_index_by_year', '__return_true' );
 		// Add posts for 3 years.
 		$this->add_a_post_for_each_of_the_last_x_years( 3 );
 		$this->build_sitemaps();
@@ -58,7 +60,8 @@ class RobotsTest extends TestCase {
 	 */
 	public function test_private_blog_outputs_no_sitemap() {
 		update_option( 'blog_public', 0 );
-		Metro_Sitemap::$index_by_year = false;
+		remove_filter( 'msm_sitemap_index_by_year', '__return_true' );
+		add_filter( 'msm_sitemap_index_by_year', '__return_false' );
 		$output                       = Metro_Sitemap::robots_txt( '', '0' );
 		$this->assertStringNotContainsString( 'Sitemap: ', $output );
 	}
@@ -67,7 +70,8 @@ class RobotsTest extends TestCase {
 	 * Test that a custom home URL is used in sitemap lines.
 	 */
 	public function test_custom_home_url_is_used_in_sitemap_lines() {
-		Metro_Sitemap::$index_by_year = false;
+		remove_filter( 'msm_sitemap_index_by_year', '__return_true' );
+		add_filter( 'msm_sitemap_index_by_year', '__return_false' );
 		$custom_url                   = 'https://custom.example.com';
 		add_filter(
 			'home_url',

--- a/tests/SitemapIndexEntryFactoryTest.php
+++ b/tests/SitemapIndexEntryFactoryTest.php
@@ -143,11 +143,8 @@ class SitemapIndexEntryFactoryTest extends TestCase {
 	 * Test creating sitemap index entries from sitemap dates with index by year enabled.
 	 */
 	public function test_from_sitemap_dates_with_index_by_year() {
-		// Store original value
-		$original_index_by_year = \Metro_Sitemap::$index_by_year;
-		
-		// Enable index by year
-		\Metro_Sitemap::$index_by_year = true;
+		// Enable index by year for this test
+		add_filter( 'msm_sitemap_index_by_year', '__return_true' );
 
 		$sitemap_dates = array(
 			'2024-01-15 00:00:00',
@@ -174,8 +171,8 @@ class SitemapIndexEntryFactoryTest extends TestCase {
 		$this->assertStringNotContainsString( 'yyyy=', $entries[1]->loc() );
 		$this->assertEquals( '2024-01-16T00:00:00+00:00', $entries[1]->lastmod() );
 
-		// Restore original value
-		\Metro_Sitemap::$index_by_year = $original_index_by_year;
+		// Remove the filter
+		remove_filter( 'msm_sitemap_index_by_year', '__return_true' );
 	}
 
 	/**

--- a/wpcom-helper.php
+++ b/wpcom-helper.php
@@ -25,7 +25,7 @@ function msm_wpcom_schedule_sitemap_update_for_year_month_date( $date, $time ) {
  * @param string $day
  */
 function msm_sitemap_wpcom_queue_cache_invalidation( $sitemap_id, $year, $month, $day ) {
-	$sitemap_url = Site::get_home_url( '/sitemap.xml' );
+			$sitemap_url = Site::get_sitemap_index_url();
 
 	$sitemap_urls = array(
 		$sitemap_url,


### PR DESCRIPTION
Refactored the sitemap generation logic to utilize the new Site class methods for generating sitemap URLs. Replaced direct calls to get_home_url() with get_sitemap_index_url() for improved clarity and maintainability. This change ensures consistent URL handling across the application and enhances the modularity of the codebase. Updated related tests to reflect these changes.