### PR TITLE
Increase minimum supported WordPress version to 6.4

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        wordpress: [ '5.9', '6.8' ]
+        wordpress: [ '6.4', 'latest' ]
         php: [ '7.4', '8.3' ]
         allowed_failure: [ false ]
         include:

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -43,7 +43,7 @@
 	<!-- <rule ref="WordPress-Docs"/> -->
 	<!-- For help in understanding these custom sniff properties:
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="5.9"/>
+	<config name="minimum_supported_wp_version" value="6.4"/>
 
 	<!-- Rules: WordPress VIP - see
 		https://github.com/Automattic/VIP-Coding-Standards -->

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Metro Sitemap
 
 Stable tag: 1.5.3  
-Requires at least: 5.9  
+Requires at least: 6.4  
 Tested up to: 6.8  
 Requires PHP: 7.4  
 License: GPLv2 or later  

--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -12,7 +12,7 @@
  * Plugin URI:        https://github.com/Automattic/msm-sitemap
  * Description:       Comprehensive sitemaps for your WordPress site.
  * Version:           1.5.3
- * Requires at least: 5.9
+ * Requires at least: 6.4
  * Requires PHP:      7.4
  * Author:            Metro.co.uk, MAKE, Alley Interactive, WordPress VIP.
  * Text Domain:       msm-sitemap


### PR DESCRIPTION
## Summary

Bumps the minimum required WordPress version to 6.4.

## Why

WordPress 6.4 provides a more modern baseline, with 85.1% of WordPress sites running 6.4 or later. WP 6.4 drops support for PHP 5.6, aligning with current PHP support policies.

## Testing

No functional changes - this only updates metadata and code standards configuration.