### PR TITLE
chore: migrate dependabot reviewers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# The following teams will get auto-tagged for a review.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @Automattic/vip-plugins

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,6 @@ updates:
         patterns: ["*"]
     labels:
       - "dependencies"
-    reviewers:
-      - "Automattic/vip-plugins"
     commit-message:
       prefix: "Actions"
       include: "scope"
@@ -35,8 +33,6 @@ updates:
           - "yoast/*"
     labels:
       - "dependencies"
-    reviewers:
-      - "Automattic/vip-plugins"
     commit-message:
       prefix: "Composer"
       include: "scope"
@@ -54,8 +50,6 @@ updates:
           - "@wordpress/*"
     labels:
       - "dependencies"
-    reviewers:
-      - "Automattic/vip-plugins"
     commit-message:
       prefix: "npm"
       include: "scope"


### PR DESCRIPTION
## Summary
- Add CODEOWNERS file to automatically assign @Automattic/vip-plugins as reviewers for all PRs
- Remove reviewers from dependabot.yml (now handled by CODEOWNERS)

See: https://github.com/dependabot/codeowner-migration-action

🤖 Generated with [Claude Code](https://claude.com/claude-code)