### PR TITLE
ci: standardise WP_ENV_CORE format

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,8 +43,7 @@ jobs:
             php: 'latest'
 
     env:
-      WP_ENV_PHP_VERSION: ${{ matrix.php }}
-      WP_ENV_CORE: ${{ matrix.wordpress == 'master' && 'WordPress/WordPress#master' || format('https://wordpress.org/wordpress-{0}.zip', matrix.wordpress) }}
+      WP_ENV_CORE: WordPress/WordPress#${{ matrix.wordpress }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Simplifies WP_ENV_CORE to use the standard `WordPress/WordPress#${{ matrix.wordpress }}` format
- Removes WP_ENV_PHP_VERSION since wp-env gets this from .wp-env.json configuration
- Aligns with other Automattic plugin CI workflows

## Test plan
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)