### PR TITLE
Add contextual help tabs to admin page

### DIFF
--- a/includes/Admin/HelpTabs.php
+++ b/includes/Admin/HelpTabs.php
@@ -1,0 +1,278 @@
+<?php
+/**
+ * Admin Help Tabs
+ *
+ * Provides contextual help for the MSM Sitemap admin page.
+ *
+ * @package MSM_Sitemap
+ */
+
+namespace Automattic\MSM_Sitemap\Admin;
+
+/**
+ * Handles contextual help tabs for the admin page.
+ */
+class HelpTabs {
+
+	/**
+	 * Set up help tab hooks.
+	 *
+	 * This should be called after the admin menu is registered.
+	 *
+	 * @param string $page_hook The admin page hook suffix.
+	 */
+	public static function setup( string $page_hook ): void {
+		add_action( 'load-' . $page_hook, array( __CLASS__, 'add_help_tabs' ) );
+	}
+
+	/**
+	 * Add help tabs to the admin page.
+	 */
+	public static function add_help_tabs(): void {
+		$screen = get_current_screen();
+
+		if ( ! $screen ) {
+			return;
+		}
+
+		// Overview tab.
+		$screen->add_help_tab(
+			array(
+				'id'      => 'msm-sitemap-overview',
+				'title'   => __( 'Overview', 'msm-sitemap' ),
+				'content' => self::get_overview_content(),
+			)
+		);
+
+		// Automatic Updates tab.
+		$screen->add_help_tab(
+			array(
+				'id'      => 'msm-sitemap-auto-updates',
+				'title'   => __( 'Automatic Updates', 'msm-sitemap' ),
+				'content' => self::get_auto_updates_content(),
+			)
+		);
+
+		// Generating Sitemaps tab.
+		$screen->add_help_tab(
+			array(
+				'id'      => 'msm-sitemap-generation',
+				'title'   => __( 'Generating Sitemaps', 'msm-sitemap' ),
+				'content' => self::get_generation_content(),
+			)
+		);
+
+		// Statistics tab.
+		$screen->add_help_tab(
+			array(
+				'id'      => 'msm-sitemap-statistics',
+				'title'   => __( 'Statistics', 'msm-sitemap' ),
+				'content' => self::get_statistics_content(),
+			)
+		);
+
+		// WP-CLI tab.
+		$screen->add_help_tab(
+			array(
+				'id'      => 'msm-sitemap-cli',
+				'title'   => __( 'WP-CLI Commands', 'msm-sitemap' ),
+				'content' => self::get_cli_content(),
+			)
+		);
+
+		// Troubleshooting tab.
+		$screen->add_help_tab(
+			array(
+				'id'      => 'msm-sitemap-troubleshooting',
+				'title'   => __( 'Troubleshooting', 'msm-sitemap' ),
+				'content' => self::get_troubleshooting_content(),
+			)
+		);
+
+		// Help sidebar.
+		$screen->set_help_sidebar( self::get_help_sidebar() );
+	}
+
+	/**
+	 * Get the overview help content.
+	 *
+	 * @return string
+	 */
+	private static function get_overview_content(): string {
+		$content  = '<h3>' . esc_html__( 'MSM Sitemap', 'msm-sitemap' ) . '</h3>';
+		$content .= '<p>' . esc_html__( 'MSM Sitemap generates XML sitemaps for your WordPress site to help search engines discover and index your content more efficiently.', 'msm-sitemap' ) . '</p>';
+		$content .= '<p>' . esc_html__( 'Key features:', 'msm-sitemap' ) . '</p>';
+		$content .= '<ul>';
+		$content .= '<li>' . esc_html__( 'Automatic sitemap generation based on your content', 'msm-sitemap' ) . '</li>';
+		$content .= '<li>' . esc_html__( 'Daily sitemaps organized by date for efficient updates', 'msm-sitemap' ) . '</li>';
+		$content .= '<li>' . esc_html__( 'Sitemap index with all daily sitemaps', 'msm-sitemap' ) . '</li>';
+		$content .= '<li>' . esc_html__( 'Automatic updates when content changes', 'msm-sitemap' ) . '</li>';
+		$content .= '<li>' . esc_html__( 'WP-CLI commands for advanced management', 'msm-sitemap' ) . '</li>';
+		$content .= '</ul>';
+
+		return $content;
+	}
+
+	/**
+	 * Get the automatic updates help content.
+	 *
+	 * @return string
+	 */
+	private static function get_auto_updates_content(): string {
+		$content  = '<h3>' . esc_html__( 'Automatic Sitemap Updates', 'msm-sitemap' ) . '</h3>';
+		$content .= '<p>' . esc_html__( 'When enabled, MSM Sitemap automatically checks for content changes and updates affected sitemaps.', 'msm-sitemap' ) . '</p>';
+
+		$content .= '<h4>' . esc_html__( 'Status', 'msm-sitemap' ) . '</h4>';
+		$content .= '<p>' . esc_html__( 'Shows whether automatic updates are enabled or disabled. Click the button to toggle.', 'msm-sitemap' ) . '</p>';
+
+		$content .= '<h4>' . esc_html__( 'Last Checked vs Last Updated', 'msm-sitemap' ) . '</h4>';
+		$content .= '<ul>';
+		$content .= '<li><strong>' . esc_html__( 'Last Checked:', 'msm-sitemap' ) . '</strong> ' . esc_html__( 'When the cron job last ran to check for changes', 'msm-sitemap' ) . '</li>';
+		$content .= '<li><strong>' . esc_html__( 'Last Updated:', 'msm-sitemap' ) . '</strong> ' . esc_html__( 'When sitemaps were actually regenerated (only happens when content changed)', 'msm-sitemap' ) . '</li>';
+		$content .= '</ul>';
+
+		$content .= '<h4>' . esc_html__( 'Frequency', 'msm-sitemap' ) . '</h4>';
+		$content .= '<p>' . esc_html__( 'Controls how often the plugin checks for content changes. More frequent checks mean faster sitemap updates but slightly more server load.', 'msm-sitemap' ) . '</p>';
+		$content .= '<ul>';
+		$content .= '<li>' . esc_html__( 'High-traffic sites: 5-15 minutes recommended', 'msm-sitemap' ) . '</li>';
+		$content .= '<li>' . esc_html__( 'Medium-traffic sites: 30-60 minutes recommended', 'msm-sitemap' ) . '</li>';
+		$content .= '<li>' . esc_html__( 'Low-traffic sites: 1-3 hours is usually sufficient', 'msm-sitemap' ) . '</li>';
+		$content .= '</ul>';
+
+		return $content;
+	}
+
+	/**
+	 * Get the generation help content.
+	 *
+	 * @return string
+	 */
+	private static function get_generation_content(): string {
+		$content = '<h3>' . esc_html__( 'Generating Sitemaps', 'msm-sitemap' ) . '</h3>';
+
+		$content .= '<h4>' . esc_html__( 'Missing Sitemaps', 'msm-sitemap' ) . '</h4>';
+		$content .= '<p>' . esc_html__( 'Shows dates that have content but no sitemap. Use "Generate Missing Sitemaps" to create sitemaps only for these dates. This is the recommended option for most cases.', 'msm-sitemap' ) . '</p>';
+
+		$content .= '<h4>' . esc_html__( 'Generate All Sitemaps (Force)', 'msm-sitemap' ) . '</h4>';
+		$content .= '<p>' . esc_html__( 'Found in the Danger Zone. This regenerates ALL sitemaps, even those that already exist. Use this only if:', 'msm-sitemap' ) . '</p>';
+		$content .= '<ul>';
+		$content .= '<li>' . esc_html__( 'You suspect existing sitemaps are corrupted or incomplete', 'msm-sitemap' ) . '</li>';
+		$content .= '<li>' . esc_html__( 'You changed which post types to include in sitemaps', 'msm-sitemap' ) . '</li>';
+		$content .= '<li>' . esc_html__( 'You need to update URL structures across all sitemaps', 'msm-sitemap' ) . '</li>';
+		$content .= '</ul>';
+
+		$content .= '<h4>' . esc_html__( 'How Generation Works', 'msm-sitemap' ) . '</h4>';
+		$content .= '<p>' . esc_html__( 'Sitemaps are generated via WordPress cron in batches to avoid timeout issues. You can continue using the admin while generation runs in the background.', 'msm-sitemap' ) . '</p>';
+
+		return $content;
+	}
+
+	/**
+	 * Get the statistics help content.
+	 *
+	 * @return string
+	 */
+	private static function get_statistics_content(): string {
+		$content  = '<h3>' . esc_html__( 'Sitemap Statistics', 'msm-sitemap' ) . '</h3>';
+		$content .= '<p>' . esc_html__( 'The statistics section provides insights into your sitemap health and content coverage.', 'msm-sitemap' ) . '</p>';
+
+		$content .= '<h4>' . esc_html__( 'Date Range Filter', 'msm-sitemap' ) . '</h4>';
+		$content .= '<p>' . esc_html__( 'Filter statistics by time period: all time, recent days, specific year, or custom date range.', 'msm-sitemap' ) . '</p>';
+
+		$content .= '<h4>' . esc_html__( 'Key Metrics', 'msm-sitemap' ) . '</h4>';
+		$content .= '<ul>';
+		$content .= '<li><strong>' . esc_html__( 'Health:', 'msm-sitemap' ) . '</strong> ' . esc_html__( 'Total sitemaps, indexed URLs, and success rate', 'msm-sitemap' ) . '</li>';
+		$content .= '<li><strong>' . esc_html__( 'Trends:', 'msm-sitemap' ) . '</strong> ' . esc_html__( 'Whether your URL counts are growing, stable, or declining', 'msm-sitemap' ) . '</li>';
+		$content .= '<li><strong>' . esc_html__( 'Content Analysis:', 'msm-sitemap' ) . '</strong> ' . esc_html__( 'Breakdown by content type and post type', 'msm-sitemap' ) . '</li>';
+		$content .= '<li><strong>' . esc_html__( 'Coverage:', 'msm-sitemap' ) . '</strong> ' . esc_html__( 'Date range covered and any gaps in coverage', 'msm-sitemap' ) . '</li>';
+		$content .= '<li><strong>' . esc_html__( 'Storage:', 'msm-sitemap' ) . '</strong> ' . esc_html__( 'Database space used by sitemap data', 'msm-sitemap' ) . '</li>';
+		$content .= '</ul>';
+
+		return $content;
+	}
+
+	/**
+	 * Get the CLI help content.
+	 *
+	 * @return string
+	 */
+	private static function get_cli_content(): string {
+		$content  = '<h3>' . esc_html__( 'WP-CLI Commands', 'msm-sitemap' ) . '</h3>';
+		$content .= '<p>' . esc_html__( 'MSM Sitemap includes WP-CLI commands for advanced sitemap management.', 'msm-sitemap' ) . '</p>';
+
+		$content .= '<h4>' . esc_html__( 'Available Commands', 'msm-sitemap' ) . '</h4>';
+		$content .= '<pre style="background: #f5f5f5; padding: 10px; overflow-x: auto;">';
+		$content .= esc_html__( '# List all sitemaps', 'msm-sitemap' ) . "\n";
+		$content .= 'wp msm-sitemap list' . "\n\n";
+		$content .= esc_html__( '# Get a specific sitemap by date or ID', 'msm-sitemap' ) . "\n";
+		$content .= 'wp msm-sitemap get 2024-01-15' . "\n";
+		$content .= 'wp msm-sitemap get 123' . "\n\n";
+		$content .= esc_html__( '# Generate sitemap for a specific date', 'msm-sitemap' ) . "\n";
+		$content .= 'wp msm-sitemap generate --date=2024-01-15' . "\n\n";
+		$content .= esc_html__( '# Generate all missing sitemaps', 'msm-sitemap' ) . "\n";
+		$content .= 'wp msm-sitemap generate --missing' . "\n\n";
+		$content .= esc_html__( '# Delete sitemap for a specific date', 'msm-sitemap' ) . "\n";
+		$content .= 'wp msm-sitemap delete 2024-01-15' . "\n\n";
+		$content .= esc_html__( '# View cron status', 'msm-sitemap' ) . "\n";
+		$content .= 'wp msm-sitemap cron status' . "\n\n";
+		$content .= esc_html__( '# Enable/disable cron', 'msm-sitemap' ) . "\n";
+		$content .= 'wp msm-sitemap cron enable' . "\n";
+		$content .= 'wp msm-sitemap cron disable' . "\n";
+		$content .= '</pre>';
+
+		$content .= '<p>' . esc_html__( 'For full command documentation:', 'msm-sitemap' ) . ' <code>wp help msm-sitemap</code></p>';
+
+		return $content;
+	}
+
+	/**
+	 * Get the troubleshooting help content.
+	 *
+	 * @return string
+	 */
+	private static function get_troubleshooting_content(): string {
+		$content = '<h3>' . esc_html__( 'Troubleshooting', 'msm-sitemap' ) . '</h3>';
+
+		$content .= '<h4>' . esc_html__( 'Sitemaps Not Updating', 'msm-sitemap' ) . '</h4>';
+		$content .= '<ul>';
+		$content .= '<li>' . esc_html__( 'Check that automatic updates are enabled', 'msm-sitemap' ) . '</li>';
+		$content .= '<li>' . esc_html__( 'Verify WordPress cron is running (wp-cron.php)', 'msm-sitemap' ) . '</li>';
+		$content .= '<li>' . esc_html__( 'Check "Last Checked" time - if it\'s not updating, cron may be disabled', 'msm-sitemap' ) . '</li>';
+		$content .= '<li>' . esc_html__( 'Try manually generating missing sitemaps', 'msm-sitemap' ) . '</li>';
+		$content .= '</ul>';
+
+		$content .= '<h4>' . esc_html__( 'Missing Content in Sitemaps', 'msm-sitemap' ) . '</h4>';
+		$content .= '<ul>';
+		$content .= '<li>' . esc_html__( 'Only published posts are included', 'msm-sitemap' ) . '</li>';
+		$content .= '<li>' . esc_html__( 'By default, only "post" post type is included', 'msm-sitemap' ) . '</li>';
+		$content .= '<li>' . esc_html__( 'Use the msm_sitemap_entry_post_type filter to add custom post types', 'msm-sitemap' ) . '</li>';
+		$content .= '<li>' . esc_html__( 'Check if content has noindex meta tags', 'msm-sitemap' ) . '</li>';
+		$content .= '</ul>';
+
+		$content .= '<h4>' . esc_html__( 'Generation Taking Too Long', 'msm-sitemap' ) . '</h4>';
+		$content .= '<ul>';
+		$content .= '<li>' . esc_html__( 'Large sites may take several hours for full generation', 'msm-sitemap' ) . '</li>';
+		$content .= '<li>' . esc_html__( 'Generation runs in background batches to avoid timeouts', 'msm-sitemap' ) . '</li>';
+		$content .= '<li>' . esc_html__( 'Use WP-CLI for faster generation: wp msm-sitemap generate --all', 'msm-sitemap' ) . '</li>';
+		$content .= '</ul>';
+
+		$content .= '<h4>' . esc_html__( 'Private Site Warning', 'msm-sitemap' ) . '</h4>';
+		$content .= '<p>' . esc_html__( 'If your site is set to "Discourage search engines" in Settings > Reading, sitemaps will be disabled. Search engines should not index private sites.', 'msm-sitemap' ) . '</p>';
+
+		return $content;
+	}
+
+	/**
+	 * Get the help sidebar content.
+	 *
+	 * @return string
+	 */
+	private static function get_help_sidebar(): string {
+		$content  = '<p><strong>' . esc_html__( 'Resources', 'msm-sitemap' ) . '</strong></p>';
+		$content .= '<p><a href="https://github.com/Automattic/msm-sitemap" target="_blank">' . esc_html__( 'GitHub Repository', 'msm-sitemap' ) . '</a></p>';
+		$content .= '<p><a href="https://github.com/Automattic/msm-sitemap/issues" target="_blank">' . esc_html__( 'Report an Issue', 'msm-sitemap' ) . '</a></p>';
+		$content .= '<p><a href="https://github.com/Automattic/msm-sitemap#readme" target="_blank">' . esc_html__( 'Documentation', 'msm-sitemap' ) . '</a></p>';
+
+		return $content;
+	}
+}

--- a/includes/Admin/UI.php
+++ b/includes/Admin/UI.php
@@ -29,14 +29,17 @@ class UI {
 	 * Register admin menu for sitemap
 	 */
 	public static function register_admin_menu() {
-		$page_hook = add_options_page( 
-			__( 'MSM Sitemap', 'msm-sitemap' ), 
-			__( 'Sitemap', 'msm-sitemap' ), 
-			'manage_options', 
-			'msm-sitemap', 
-			array( __CLASS__, 'render_options_page' ) 
+		$page_hook = add_options_page(
+			__( 'MSM Sitemap', 'msm-sitemap' ),
+			__( 'Sitemap', 'msm-sitemap' ),
+			'manage_options',
+			'msm-sitemap',
+			array( __CLASS__, 'render_options_page' )
 		);
 		add_action( 'admin_print_scripts-' . $page_hook, array( __CLASS__, 'enqueue_admin_assets' ) );
+
+		// Add contextual help tabs.
+		HelpTabs::setup( $page_hook );
 	}
 
 	/**

--- a/tests/Admin/HelpTabsTest.php
+++ b/tests/Admin/HelpTabsTest.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * Tests for Admin HelpTabs class.
+ *
+ * @package Automattic\MSM_Sitemap\Tests\Admin
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\MSM_Sitemap\Tests\Admin;
+
+use Automattic\MSM_Sitemap\Admin\HelpTabs;
+use Automattic\MSM_Sitemap\Tests\TestCase;
+
+/**
+ * Tests for HelpTabs class.
+ */
+class HelpTabsTest extends TestCase {
+
+	/**
+	 * Admin user ID.
+	 *
+	 * @var int
+	 */
+	protected int $admin_id;
+
+	/**
+	 * Set up the test environment.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	/**
+	 * Test that setup registers the load action.
+	 */
+	public function test_setup_registers_load_action(): void {
+		$page_hook = 'settings_page_msm-sitemap';
+
+		// Remove any existing action first.
+		remove_action( 'load-' . $page_hook, array( HelpTabs::class, 'add_help_tabs' ) );
+
+		// Call setup.
+		HelpTabs::setup( $page_hook );
+
+		// Verify the action is registered.
+		$this->assertGreaterThan(
+			0,
+			has_action( 'load-' . $page_hook, array( HelpTabs::class, 'add_help_tabs' ) )
+		);
+
+		// Clean up.
+		remove_action( 'load-' . $page_hook, array( HelpTabs::class, 'add_help_tabs' ) );
+	}
+
+	/**
+	 * Test that help tabs are added to the screen.
+	 */
+	public function test_add_help_tabs_adds_tabs_to_screen(): void {
+		wp_set_current_user( $this->admin_id );
+		set_current_screen( 'settings_page_msm-sitemap' );
+
+		$screen = get_current_screen();
+		$this->assertNotNull( $screen );
+
+		// Call the method.
+		HelpTabs::add_help_tabs();
+
+		// Get the help tabs.
+		$tabs = $screen->get_help_tabs();
+
+		// Verify tabs are added.
+		$expected_tabs = array(
+			'msm-sitemap-overview',
+			'msm-sitemap-auto-updates',
+			'msm-sitemap-generation',
+			'msm-sitemap-statistics',
+			'msm-sitemap-cli',
+			'msm-sitemap-troubleshooting',
+		);
+
+		foreach ( $expected_tabs as $tab_id ) {
+			$this->assertArrayHasKey( $tab_id, $tabs, "Help tab '$tab_id' should be registered." );
+		}
+	}
+
+	/**
+	 * Test that overview tab contains expected content.
+	 */
+	public function test_overview_tab_content(): void {
+		wp_set_current_user( $this->admin_id );
+		set_current_screen( 'settings_page_msm-sitemap' );
+
+		$screen = get_current_screen();
+		HelpTabs::add_help_tabs();
+
+		$tabs         = $screen->get_help_tabs();
+		$overview_tab = $tabs['msm-sitemap-overview'] ?? null;
+
+		$this->assertNotNull( $overview_tab );
+		$this->assertStringContainsString( 'MSM Sitemap', $overview_tab['content'] );
+		$this->assertStringContainsString( 'XML sitemaps', $overview_tab['content'] );
+	}
+
+	/**
+	 * Test that auto updates tab contains expected content.
+	 */
+	public function test_auto_updates_tab_content(): void {
+		wp_set_current_user( $this->admin_id );
+		set_current_screen( 'settings_page_msm-sitemap' );
+
+		$screen = get_current_screen();
+		HelpTabs::add_help_tabs();
+
+		$tabs = $screen->get_help_tabs();
+		$tab  = $tabs['msm-sitemap-auto-updates'] ?? null;
+
+		$this->assertNotNull( $tab );
+		$this->assertStringContainsString( 'Automatic', $tab['content'] );
+		$this->assertStringContainsString( 'Frequency', $tab['content'] );
+	}
+
+	/**
+	 * Test that generation tab contains expected content.
+	 */
+	public function test_generation_tab_content(): void {
+		wp_set_current_user( $this->admin_id );
+		set_current_screen( 'settings_page_msm-sitemap' );
+
+		$screen = get_current_screen();
+		HelpTabs::add_help_tabs();
+
+		$tabs = $screen->get_help_tabs();
+		$tab  = $tabs['msm-sitemap-generation'] ?? null;
+
+		$this->assertNotNull( $tab );
+		$this->assertStringContainsString( 'Missing Sitemaps', $tab['content'] );
+		$this->assertStringContainsString( 'Generate', $tab['content'] );
+	}
+
+	/**
+	 * Test that CLI tab contains expected content.
+	 */
+	public function test_cli_tab_content(): void {
+		wp_set_current_user( $this->admin_id );
+		set_current_screen( 'settings_page_msm-sitemap' );
+
+		$screen = get_current_screen();
+		HelpTabs::add_help_tabs();
+
+		$tabs = $screen->get_help_tabs();
+		$tab  = $tabs['msm-sitemap-cli'] ?? null;
+
+		$this->assertNotNull( $tab );
+		$this->assertStringContainsString( 'WP-CLI', $tab['content'] );
+		$this->assertStringContainsString( 'wp msm-sitemap', $tab['content'] );
+	}
+
+	/**
+	 * Test that troubleshooting tab contains expected content.
+	 */
+	public function test_troubleshooting_tab_content(): void {
+		wp_set_current_user( $this->admin_id );
+		set_current_screen( 'settings_page_msm-sitemap' );
+
+		$screen = get_current_screen();
+		HelpTabs::add_help_tabs();
+
+		$tabs = $screen->get_help_tabs();
+		$tab  = $tabs['msm-sitemap-troubleshooting'] ?? null;
+
+		$this->assertNotNull( $tab );
+		$this->assertStringContainsString( 'Troubleshooting', $tab['content'] );
+		$this->assertStringContainsString( 'cron', $tab['content'] );
+	}
+
+	/**
+	 * Test that help sidebar is set.
+	 */
+	public function test_help_sidebar_is_set(): void {
+		wp_set_current_user( $this->admin_id );
+		set_current_screen( 'settings_page_msm-sitemap' );
+
+		$screen = get_current_screen();
+		HelpTabs::add_help_tabs();
+
+		$sidebar = $screen->get_help_sidebar();
+
+		$this->assertNotEmpty( $sidebar );
+		$this->assertStringContainsString( 'GitHub', $sidebar );
+		$this->assertStringContainsString( 'Documentation', $sidebar );
+	}
+
+	/**
+	 * Test that add_help_tabs handles null screen gracefully.
+	 */
+	public function test_add_help_tabs_handles_null_screen(): void {
+		// Reset current screen to null to test the early return guard.
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Testing edge case behaviour.
+		$GLOBALS['current_screen'] = null;
+
+		// This should not throw an error.
+		HelpTabs::add_help_tabs();
+
+		// If we get here, the test passed.
+		$this->assertTrue( true );
+	}
+}


### PR DESCRIPTION
## Summary

- Adds WordPress contextual help tabs to the MSM Sitemap admin page using the native `WP_Screen` help tab API
- Provides in-context documentation so users can get help without leaving the admin interface
- Includes 6 help tabs covering all major features and a sidebar with resource links

## Help Tabs

| Tab | Content |
|-----|---------|
| Overview | Introduction to MSM Sitemap features |
| Automatic Updates | Cron behaviour, frequency settings, Last Checked vs Last Updated |
| Generating Sitemaps | Missing sitemaps vs force generation, when to use each |
| Statistics | Explanation of metrics, date filters, and what each stat means |
| WP-CLI Commands | Full command reference with copy-pasteable examples |
| Troubleshooting | Common issues and solutions (cron, missing content, performance) |

## Files Changed

- `includes/Admin/HelpTabs.php` (new) - Help tabs class with all content
- `includes/Admin/UI.php` - Hooks HelpTabs into admin page load
- `tests/Admin/HelpTabsTest.php` (new) - 9 tests for help tab registration and content

## Test plan

- [x] Visit Settings > Sitemap in WordPress admin
- [x] Click "Help" tab in top-right corner of screen
- [x] Verify all 6 tabs are present and contain relevant content
- [x] Verify sidebar shows GitHub/documentation links
- [x] Run `composer test:integration -- --filter=HelpTabs` (9 tests should pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)