### PR TITLE
feat: add filter to enable sitemaps on non-public sites

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -96,6 +96,34 @@ function my_filter_sitemap_index( array $sitemaps, $year ) : array {
 }
 ```
 
+### Control Sitemap Availability on Non-Public Sites
+
+**Business case:**
+By default, sitemaps are only available when `blog_public` is set to `1`. However, you may need sitemaps accessible on staging or development environments that aren't marked as public, without affecting other SEO-related features tied to `blog_public`. This filter provides granular control over sitemap availability independently of the site's public status.
+
+```php
+add_filter( 'msm_sitemap_is_enabled', 'my_enable_sitemaps_on_staging' );
+/**
+ * Enable sitemaps on staging environments regardless of blog_public setting.
+ *
+ * @param bool $is_enabled Whether sitemaps are enabled (default: based on blog_public).
+ * @return bool True to enable sitemaps, false to disable.
+ */
+function my_enable_sitemaps_on_staging( bool $is_enabled ): bool {
+    // Enable sitemaps on staging environments
+    if ( wp_get_environment_type() === 'staging' ) {
+        return true;
+    }
+
+    // Or disable sitemaps during maintenance even on public sites
+    if ( defined( 'WP_MAINTENANCE_MODE' ) && WP_MAINTENANCE_MODE ) {
+        return false;
+    }
+
+    return $is_enabled;
+}
+```
+
 ### Override Cron Status (Testing)
 
 **Business case:**
@@ -112,7 +140,7 @@ add_filter( 'msm_sitemap_cron_enabled', 'my_override_cron_status' );
 function my_override_cron_status( bool $enabled ): bool {
     // Force cron to be enabled for testing
     return true;
-    
+
     // Or force it to be disabled
     // return false;
 }

--- a/includes/Domain/ValueObjects/Site.php
+++ b/includes/Domain/ValueObjects/Site.php
@@ -30,6 +30,34 @@ class Site {
 	}
 
 	/**
+	 * Check if MSM Sitemaps are enabled.
+	 *
+	 * By default, sitemaps are enabled when the site is public. This method
+	 * provides a filter to allow enabling sitemaps on non-public sites
+	 * (e.g., staging environments) without affecting the broader blog_public
+	 * setting that may impact other SEO-related features.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @return bool True if sitemaps are enabled, false otherwise.
+	 */
+	public static function are_sitemaps_enabled(): bool {
+		$is_public = self::is_public();
+
+		/**
+		 * Filters whether MSM Sitemaps are enabled.
+		 *
+		 * Allows enabling sitemaps on non-public sites (e.g., staging environments)
+		 * without affecting the broader blog_public setting.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param bool $is_enabled Whether sitemaps are enabled. Default is based on blog_public.
+		 */
+		return (bool) apply_filters( 'msm_sitemap_is_enabled', $is_public );
+	}
+
+	/**
 	 * Get the home URL for the site.
 	 *
 	 * Returns the home URL of the site, which is typically used for

--- a/includes/Infrastructure/REST/SitemapEndpointHandler.php
+++ b/includes/Infrastructure/REST/SitemapEndpointHandler.php
@@ -66,10 +66,10 @@ class SitemapEndpointHandler {
 	 * Handle sitemap requests and output appropriate responses.
 	 */
 	public function handle_sitemap_request(): void {
-		// Check if site is public
-		if ( ! Site::is_public() ) {
-			$this->send_sitemap_error_response( 
-				__( 'Sorry, this site is not public so sitemaps are not available.', 'msm-sitemap' )
+		// Check if sitemaps are enabled
+		if ( ! Site::are_sitemaps_enabled() ) {
+			$this->send_sitemap_error_response(
+				__( 'Sorry, sitemaps are not available on this site.', 'msm-sitemap' )
 			);
 			return;
 		}

--- a/includes/Infrastructure/WordPress/Admin/UI.php
+++ b/includes/Infrastructure/WordPress/Admin/UI.php
@@ -185,8 +185,8 @@ class UI implements WordPressIntegrationInterface {
 			wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'msm-sitemap' ) );
 		}
 
-		// Check if blog is public
-		if ( ! Site::is_public() ) {
+		// Check if sitemaps are enabled
+		if ( ! Site::are_sitemaps_enabled() ) {
 			$this->render_private_site_message();
 			return;
 		}

--- a/tests/Domain/ValueObjects/SiteTest.php
+++ b/tests/Domain/ValueObjects/SiteTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Tests for Site Value Object.
+ *
+ * @package Automattic\MSM_Sitemap\Tests\Domain\ValueObjects
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\MSM_Sitemap\Tests\Domain\ValueObjects;
+
+use Automattic\MSM_Sitemap\Domain\ValueObjects\Site;
+use Automattic\MSM_Sitemap\Tests\TestCase;
+
+/**
+ * Test class for Site Value Object.
+ */
+class SiteTest extends TestCase {
+
+	/**
+	 * Test is_public returns true when blog_public is '1'.
+	 */
+	public function test_is_public_returns_true_when_blog_public(): void {
+		update_option( 'blog_public', '1' );
+
+		$this->assertTrue( Site::is_public() );
+	}
+
+	/**
+	 * Test is_public returns false when blog_public is '0'.
+	 */
+	public function test_is_public_returns_false_when_not_blog_public(): void {
+		update_option( 'blog_public', '0' );
+
+		$this->assertFalse( Site::is_public() );
+	}
+
+	/**
+	 * Test are_sitemaps_enabled returns true when blog is public.
+	 */
+	public function test_are_sitemaps_enabled_returns_true_when_public(): void {
+		update_option( 'blog_public', '1' );
+
+		$this->assertTrue( Site::are_sitemaps_enabled() );
+	}
+
+	/**
+	 * Test are_sitemaps_enabled returns false when blog is not public.
+	 */
+	public function test_are_sitemaps_enabled_returns_false_when_not_public(): void {
+		update_option( 'blog_public', '0' );
+
+		$this->assertFalse( Site::are_sitemaps_enabled() );
+	}
+
+	/**
+	 * Test msm_sitemap_is_enabled filter can enable sitemaps on non-public site.
+	 */
+	public function test_filter_can_enable_sitemaps_on_non_public_site(): void {
+		update_option( 'blog_public', '0' );
+
+		// Add filter to enable sitemaps
+		add_filter( 'msm_sitemap_is_enabled', '__return_true' );
+
+		$this->assertTrue( Site::are_sitemaps_enabled() );
+
+		// Clean up
+		remove_filter( 'msm_sitemap_is_enabled', '__return_true' );
+	}
+
+	/**
+	 * Test msm_sitemap_is_enabled filter can disable sitemaps on public site.
+	 */
+	public function test_filter_can_disable_sitemaps_on_public_site(): void {
+		update_option( 'blog_public', '1' );
+
+		// Add filter to disable sitemaps
+		add_filter( 'msm_sitemap_is_enabled', '__return_false' );
+
+		$this->assertFalse( Site::are_sitemaps_enabled() );
+
+		// Clean up
+		remove_filter( 'msm_sitemap_is_enabled', '__return_false' );
+	}
+
+	/**
+	 * Test msm_sitemap_is_enabled filter receives correct default value.
+	 */
+	public function test_filter_receives_correct_default_value(): void {
+		update_option( 'blog_public', '1' );
+
+		$received_value = null;
+		$filter_callback = function ( $is_enabled ) use ( &$received_value ) {
+			$received_value = $is_enabled;
+			return $is_enabled;
+		};
+
+		add_filter( 'msm_sitemap_is_enabled', $filter_callback );
+		Site::are_sitemaps_enabled();
+		remove_filter( 'msm_sitemap_is_enabled', $filter_callback );
+
+		$this->assertTrue( $received_value );
+
+		// Test with non-public site
+		update_option( 'blog_public', '0' );
+
+		add_filter( 'msm_sitemap_is_enabled', $filter_callback );
+		Site::are_sitemaps_enabled();
+		remove_filter( 'msm_sitemap_is_enabled', $filter_callback );
+
+		$this->assertFalse( $received_value );
+	}
+}


### PR DESCRIPTION
## Summary

Introduces the `msm_sitemap_is_enabled` filter to provide granular control over sitemap availability independently of the `blog_public` setting.

This addresses scenarios where sitemaps need to be accessible on staging or development environments that aren't marked as public, without affecting other SEO-related features tied to `blog_public`.

## Changes

- Added `Site::are_sitemaps_enabled()` method with `msm_sitemap_is_enabled` filter
- Updated `SitemapEndpointHandler` to use new method instead of `is_public()`
- Updated admin `UI` to use new method instead of `is_public()`
- Added comprehensive tests (7 test cases)

## Usage Example

```php
// Enable sitemaps on staging environments
add_filter( 'msm_sitemap_is_enabled', function( $is_enabled ) {
    if ( wp_get_environment_type() === 'staging' ) {
        return true;
    }
    return $is_enabled;
} );
```

## Test plan

- [ ] Verify sitemaps work normally on public sites
- [ ] Verify sitemaps are blocked on non-public sites (default behaviour)
- [ ] Verify filter can enable sitemaps on non-public sites
- [ ] Verify admin UI respects the filter

Fixes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)