### PR TITLE
fix: use site timezone for lastmod dates in URL entries

### DIFF
--- a/includes/Infrastructure/Factories/SitemapIndexEntryFactory.php
+++ b/includes/Infrastructure/Factories/SitemapIndexEntryFactory.php
@@ -28,7 +28,7 @@ class SitemapIndexEntryFactory {
 	 */
 	public static function from_post( \WP_Post $sitemap_post ): SitemapIndexEntry {
 		$loc = get_permalink( $sitemap_post );
-		$lastmod = get_post_modified_time( 'c', true, $sitemap_post );
+		$lastmod = get_post_modified_time( 'c', false, $sitemap_post );
 
 		return new SitemapIndexEntry( $loc, $lastmod );
 	}

--- a/includes/Infrastructure/Factories/UrlEntryFactory.php
+++ b/includes/Infrastructure/Factories/UrlEntryFactory.php
@@ -41,7 +41,7 @@ class UrlEntryFactory {
 			return null;
 		}
 
-		$lastmod = get_post_modified_time( 'c', true, $post );
+		$lastmod = get_post_modified_time( 'c', false, $post );
 		$changefreq = apply_filters( 'msm_sitemap_changefreq', 'monthly', $post );
 		$priority = apply_filters( 'msm_sitemap_priority', 0.7, $post );
 

--- a/tests/Integration/SitemapIndexEntryFactoryTest.php
+++ b/tests/Integration/SitemapIndexEntryFactoryTest.php
@@ -52,7 +52,7 @@ class SitemapIndexEntryFactoryTest extends TestCase {
 
 		$this->assertInstanceOf( SitemapIndexEntry::class, $entry );
 		$this->assertEquals( get_permalink( $sitemap_post ), $entry->loc() );
-		$this->assertEquals( get_post_modified_time( 'c', true, $sitemap_post ), $entry->lastmod() );
+		$this->assertEquals( get_post_modified_time( 'c', false, $sitemap_post ), $entry->lastmod() );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Extends the timezone fix from #248 to cover `UrlEntryFactory::from_post()` and `SitemapIndexEntryFactory::from_post()`.

**The problem:** These methods were using `get_post_modified_time('c', true, $post)` which returns GMT/UTC time. This is inconsistent with the fix in #248 which correctly uses the site's configured timezone.

**The fix:** Change the second parameter from `true` (GMT) to `false` (site timezone) so all lastmod dates in sitemaps use consistent timezone handling.

## Changes

| File | Method |
|------|--------|
| `SitemapIndexEntryFactory.php` | `from_post()` |
| `UrlEntryFactory.php` | `from_post()` |
| `SitemapIndexEntryFactoryTest.php` | Updated assertion to match |

## Test plan

- [x] All 319 integration tests pass
- [ ] Verify sitemap output shows correct timezone offset on a non-UTC site

🤖 Generated with [Claude Code](https://claude.com/claude-code)