### PR TITLE
fix: align image sitemap implementation with Google specification

### DIFF
--- a/includes/Domain/ValueObjects/ImageEntry.php
+++ b/includes/Domain/ValueObjects/ImageEntry.php
@@ -13,7 +13,9 @@ namespace Automattic\MSM_Sitemap\Domain\ValueObjects;
  * Image Entry Value Object
  *
  * Represents a single image entry in a sitemap following the Google Image Sitemap protocol.
- * Based on https://developers.google.com/search/docs/crawling-indexing/sitemaps/image-sitemaps
+ * Only the loc (URL) element is supported as Google has deprecated all other image sitemap tags.
+ *
+ * @see https://developers.google.com/search/docs/crawling-indexing/sitemaps/image-sitemaps
  */
 class ImageEntry {
 
@@ -25,34 +27,6 @@ class ImageEntry {
 	private string $loc;
 
 	/**
-	 * The caption of the image (optional).
-	 *
-	 * @var string|null
-	 */
-	private ?string $caption;
-
-	/**
-	 * The geographic location of the image (optional).
-	 *
-	 * @var string|null
-	 */
-	private ?string $geo_location;
-
-	/**
-	 * The title of the image (optional).
-	 *
-	 * @var string|null
-	 */
-	private ?string $title;
-
-	/**
-	 * The license URL of the image (optional).
-	 *
-	 * @var string|null
-	 */
-	private ?string $license;
-
-	/**
 	 * Maximum URL length according to sitemap protocol.
 	 *
 	 * @var int
@@ -62,32 +36,13 @@ class ImageEntry {
 	/**
 	 * Constructor.
 	 *
-	 * @param string      $loc          The URL of the image (required).
-	 * @param string|null $caption      The caption of the image (optional).
-	 * @param string|null $geo_location The geographic location of the image (optional).
-	 * @param string|null $title        The title of the image (optional).
-	 * @param string|null $license      The license URL of the image (optional).
+	 * @param string $loc The URL of the image (required).
 	 *
-	 * @throws \InvalidArgumentException If any parameter is invalid.
+	 * @throws \InvalidArgumentException If the URL is invalid.
 	 */
-	public function __construct(
-		string $loc,
-		?string $caption = null,
-		?string $geo_location = null,
-		?string $title = null,
-		?string $license = null
-	) {
+	public function __construct( string $loc ) {
 		$this->validate_loc( $loc );
-		$this->validate_caption( $caption );
-		$this->validate_geo_location( $geo_location );
-		$this->validate_title( $title );
-		$this->validate_license( $license );
-
-		$this->loc          = $loc;
-		$this->caption      = $caption;
-		$this->geo_location = $geo_location;
-		$this->title        = $title;
-		$this->license      = $license;
+		$this->loc = $loc;
 	}
 
 	/**
@@ -100,68 +55,14 @@ class ImageEntry {
 	}
 
 	/**
-	 * Get the caption of the image.
-	 *
-	 * @return string|null The image caption or null if not set.
-	 */
-	public function caption(): ?string {
-		return $this->caption;
-	}
-
-	/**
-	 * Get the geographic location of the image.
-	 *
-	 * @return string|null The geographic location or null if not set.
-	 */
-	public function geo_location(): ?string {
-		return $this->geo_location;
-	}
-
-	/**
-	 * Get the title of the image.
-	 *
-	 * @return string|null The image title or null if not set.
-	 */
-	public function title(): ?string {
-		return $this->title;
-	}
-
-	/**
-	 * Get the license URL of the image.
-	 *
-	 * @return string|null The license URL or null if not set.
-	 */
-	public function license(): ?string {
-		return $this->license;
-	}
-
-	/**
 	 * Convert the image entry to an array representation.
 	 *
-	 * @return array<string, mixed> Array representation of the image entry.
+	 * @return array<string, string> Array representation of the image entry.
 	 */
 	public function to_array(): array {
-		$array = array(
+		return array(
 			'loc' => $this->loc,
 		);
-
-		if ( null !== $this->caption ) {
-			$array['caption'] = $this->caption;
-		}
-
-		if ( null !== $this->geo_location ) {
-			$array['geo_location'] = $this->geo_location;
-		}
-
-		if ( null !== $this->title ) {
-			$array['title'] = $this->title;
-		}
-
-		if ( null !== $this->license ) {
-			$array['license'] = $this->license;
-		}
-
-		return $array;
 	}
 
 	/**
@@ -171,11 +72,7 @@ class ImageEntry {
 	 * @return bool True if equal, false otherwise.
 	 */
 	public function equals( ImageEntry $other ): bool {
-		return $this->loc === $other->loc &&
-			$this->caption === $other->caption &&
-			$this->geo_location === $other->geo_location &&
-			$this->title === $other->title &&
-			$this->license === $other->license;
+		return $this->loc === $other->loc;
 	}
 
 	/**
@@ -201,66 +98,6 @@ class ImageEntry {
 
 		if ( ! filter_var( $loc, FILTER_VALIDATE_URL ) ) {
 			throw new \InvalidArgumentException( 'Image URL must be a valid URL.' );
-		}
-	}
-
-	/**
-	 * Validate the caption parameter.
-	 *
-	 * @param string|null $caption The caption to validate.
-	 * @throws \InvalidArgumentException If the caption is invalid.
-	 */
-	private function validate_caption( ?string $caption ): void {
-		if ( null !== $caption && strlen( $caption ) > 2048 ) {
-			throw new \InvalidArgumentException( 'Image caption cannot exceed 2048 characters.' );
-		}
-	}
-
-	/**
-	 * Validate the geographic location parameter.
-	 *
-	 * @param string|null $geo_location The geographic location to validate.
-	 * @throws \InvalidArgumentException If the geographic location is invalid.
-	 */
-	private function validate_geo_location( ?string $geo_location ): void {
-		if ( null !== $geo_location && strlen( $geo_location ) > 2048 ) {
-			throw new \InvalidArgumentException( 'Geographic location cannot exceed 2048 characters.' );
-		}
-	}
-
-	/**
-	 * Validate the title parameter.
-	 *
-	 * @param string|null $title The title to validate.
-	 * @throws \InvalidArgumentException If the title is invalid.
-	 */
-	private function validate_title( ?string $title ): void {
-		if ( null !== $title && strlen( $title ) > 2048 ) {
-			throw new \InvalidArgumentException( 'Image title cannot exceed 2048 characters.' );
-		}
-	}
-
-	/**
-	 * Validate the license parameter.
-	 *
-	 * @param string|null $license The license URL to validate.
-	 * @throws \InvalidArgumentException If the license URL is invalid.
-	 */
-	private function validate_license( ?string $license ): void {
-		if ( null !== $license ) {
-			$max_length = self::MAX_URL_LENGTH;
-			if ( strlen( $license ) > $max_length ) {
-				throw new \InvalidArgumentException(
-					sprintf(
-						'License URL cannot exceed %d characters.',
-						$max_length
-					)
-				);
-			}
-
-			if ( ! filter_var( $license, FILTER_VALIDATE_URL ) ) {
-				throw new \InvalidArgumentException( 'License URL must be a valid URL.' );
-			}
 		}
 	}
 }

--- a/includes/Domain/ValueObjects/UrlEntry.php
+++ b/includes/Domain/ValueObjects/UrlEntry.php
@@ -89,6 +89,15 @@ class UrlEntry {
 	private const MAX_PRIORITY = 1.0;
 
 	/**
+	 * Maximum number of images per URL according to Google's specification.
+	 *
+	 * @see https://developers.google.com/search/docs/crawling-indexing/sitemaps/image-sitemaps
+	 *
+	 * @var int
+	 */
+	private const MAX_IMAGES_PER_URL = 1000;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string                    $loc        The URL of the page (required).
@@ -345,12 +354,28 @@ class UrlEntry {
 	/**
 	 * Validate the images parameter.
 	 *
+	 * Per Google's Image Sitemap specification, a maximum of 1000 images can be
+	 * included per URL.
+	 *
+	 * @see https://developers.google.com/search/docs/crawling-indexing/sitemaps/image-sitemaps
+	 *
 	 * @param array<ImageEntry>|null $images The images array to validate.
 	 * @throws \InvalidArgumentException If the images array is invalid.
 	 */
 	private function validate_images( ?array $images ): void {
 		if ( null === $images ) {
 			return;
+		}
+
+		if ( count( $images ) > self::MAX_IMAGES_PER_URL ) {
+			throw new \InvalidArgumentException(
+				sprintf(
+					/* translators: %1$d is the number of images provided, %2$d is the maximum allowed. */
+					__( 'Too many images: %1$d provided, maximum is %2$d per URL.', 'msm-sitemap' ),
+					count( $images ),
+					self::MAX_IMAGES_PER_URL
+				)
+			);
 		}
 
 		foreach ( $images as $image ) {

--- a/includes/Infrastructure/Factories/ImageEntryFactory.php
+++ b/includes/Infrastructure/Factories/ImageEntryFactory.php
@@ -15,8 +15,10 @@ use InvalidArgumentException;
 /**
  * Factory for creating ImageEntry objects from WordPress data.
  *
- * Handles WordPress-specific concerns like attachment retrieval and metadata
- * while keeping the domain layer pure.
+ * Per Google's Image Sitemap specification, only the loc (URL) element is required.
+ * Other elements (caption, geo_location, title, license) have been deprecated by Google.
+ *
+ * @see https://developers.google.com/search/docs/crawling-indexing/sitemaps/image-sitemaps
  */
 class ImageEntryFactory {
 
@@ -32,58 +34,22 @@ class ImageEntryFactory {
 			return null;
 		}
 
-		// Check if image should be skipped
+		// Check if image should be skipped.
 		if ( apply_filters( 'msm_sitemap_skip_image', false, $attachment_id ) ) {
 			return null;
 		}
 
-		// Get image URL
+		// Get image URL.
 		$image_url = wp_get_attachment_url( $attachment_id );
 		if ( ! $image_url ) {
 			return null;
 		}
 
-		// Get image metadata
-		$attachment_metadata = wp_get_attachment_metadata( $attachment_id );
-		
-		// Prepare image data
-		$title = $attachment->post_title;
-		if ( empty( $title ) ) {
-			$title = null;
-		}
-		
-		$caption = $attachment->post_excerpt;
-		if ( empty( $caption ) ) {
-			$caption = null;
-		}
-		
-		// Get alt text
-		$alt = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
-		if ( empty( $alt ) ) {
-			$alt = null;
-		}
-
-		// Use alt text as caption if no caption is set
-		if ( null === $caption && null !== $alt ) {
-			$caption = $alt;
-		}
-
-		// Get geographic location if available
-		$geo_location = self::get_image_geo_location( $attachment_id );
-
-		// Get license if available
-		$license = self::get_image_license( $attachment_id );
-
 		try {
-			return new ImageEntry(
-				$image_url,
-				$caption,
-				$geo_location,
-				$title,
-				$license
-			);
+			return new ImageEntry( $image_url );
 		} catch ( InvalidArgumentException $e ) {
-			// Log the error but don't break sitemap generation
+			// Log the error but don't break sitemap generation.
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			error_log( 'MSM Sitemap: Invalid image entry for attachment ' . $attachment_id . ': ' . $e->getMessage() );
 			return null;
 		}
@@ -126,7 +92,7 @@ class ImageEntryFactory {
 	/**
 	 * Create an ImageEntry from metadata item.
 	 *
-	 * @param int $attachment_id The attachment ID.
+	 * @param int                  $attachment_id The attachment ID.
 	 * @param array<string, mixed> $metadata The image metadata.
 	 * @return ImageEntry|null The image entry or null if invalid.
 	 */
@@ -135,104 +101,29 @@ class ImageEntryFactory {
 			return null;
 		}
 
-		// Check if image should be skipped
+		// Check if image should be skipped.
 		if ( apply_filters( 'msm_sitemap_skip_image', false, $attachment_id ) ) {
 			return null;
 		}
 
-		$title = $metadata['title'] ?? null;
-		if ( empty( $title ) ) {
-			$title = null;
-		}
-
-		$caption = $metadata['caption'] ?? null;
-		if ( empty( $caption ) ) {
-			$caption = null;
-		}
-
-		// Use alt text as caption if no caption is set
-		$alt = $metadata['alt'] ?? null;
-		if ( null === $caption && ! empty( $alt ) ) {
-			$caption = $alt;
-		}
-
-		// Get geographic location if available
-		$geo_location = self::get_image_geo_location( $attachment_id );
-
-		// Get license if available
-		$license = self::get_image_license( $attachment_id );
-
 		try {
-			return new ImageEntry(
-				$metadata['url'],
-				$caption,
-				$geo_location,
-				$title,
-				$license
-			);
+			return new ImageEntry( $metadata['url'] );
 		} catch ( InvalidArgumentException $e ) {
-			// Log the error but don't break sitemap generation
+			// Log the error but don't break sitemap generation.
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			error_log( 'MSM Sitemap: Invalid image entry for attachment ' . $attachment_id . ': ' . $e->getMessage() );
 			return null;
 		}
 	}
 
 	/**
-	 * Get geographic location for an image.
-	 *
-	 * @param int $attachment_id The attachment ID.
-	 * @return string|null The geographic location or null if not available.
-	 */
-	private static function get_image_geo_location( int $attachment_id ): ?string {
-		// Check for EXIF GPS data
-		$metadata = wp_get_attachment_metadata( $attachment_id );
-		if ( isset( $metadata['image_meta']['location'] ) ) {
-			return $metadata['image_meta']['location'];
-		}
-
-		// Check for custom field
-		$geo_location = get_post_meta( $attachment_id, '_msm_sitemap_geo_location', true );
-		if ( ! empty( $geo_location ) ) {
-			return $geo_location;
-		}
-
-		return null;
-	}
-
-	/**
-	 * Get license information for an image.
-	 *
-	 * @param int $attachment_id The attachment ID.
-	 * @return string|null The license URL or null if not available.
-	 */
-	private static function get_image_license( int $attachment_id ): ?string {
-		// Check for custom field
-		$license = get_post_meta( $attachment_id, '_msm_sitemap_license', true );
-		if ( ! empty( $license ) ) {
-			return $license;
-		}
-
-		return null;
-	}
-
-	/**
 	 * Create an ImageEntry from raw data (for testing or non-WordPress contexts).
 	 *
 	 * @param string $loc The URL of the image.
-	 * @param string|null $caption The caption of the image.
-	 * @param string|null $geo_location The geographic location of the image.
-	 * @param string|null $title The title of the image.
-	 * @param string|null $license The license URL of the image.
 	 * @return ImageEntry The image entry.
-	 * @throws InvalidArgumentException If any parameter is invalid.
+	 * @throws InvalidArgumentException If the URL is invalid.
 	 */
-	public static function from_data(
-		string $loc,
-		?string $caption = null,
-		?string $geo_location = null,
-		?string $title = null,
-		?string $license = null
-	): ImageEntry {
-		return new ImageEntry( $loc, $caption, $geo_location, $title, $license );
+	public static function from_data( string $loc ): ImageEntry {
+		return new ImageEntry( $loc );
 	}
 }

--- a/includes/Infrastructure/Formatters/SitemapXmlFormatter.php
+++ b/includes/Infrastructure/Formatters/SitemapXmlFormatter.php
@@ -83,29 +83,17 @@ class SitemapXmlFormatter {
 	/**
 	 * Format a single image entry to XML.
 	 *
+	 * Per Google's Image Sitemap specification, only the loc element is required.
+	 * Other elements (caption, geo_location, title, license) have been deprecated by Google.
+	 *
+	 * @see https://developers.google.com/search/docs/crawling-indexing/sitemaps/image-sitemaps
+	 *
 	 * @param ImageEntry $image The image entry to format.
 	 * @return string The XML representation of the image entry.
 	 */
 	private function format_image_entry( ImageEntry $image ): string {
 		$xml  = "\t\t<image:image>\n";
 		$xml .= "\t\t\t<image:loc>" . esc_xml( $image->loc() ) . "</image:loc>\n";
-
-		if ( $image->title() ) {
-			$xml .= "\t\t\t<image:title>" . esc_xml( $image->title() ) . "</image:title>\n";
-		}
-
-		if ( $image->caption() ) {
-			$xml .= "\t\t\t<image:caption>" . esc_xml( $image->caption() ) . "</image:caption>\n";
-		}
-
-		if ( $image->geo_location() ) {
-			$xml .= "\t\t\t<image:geo_location>" . esc_xml( $image->geo_location() ) . "</image:geo_location>\n";
-		}
-
-		if ( $image->license() ) {
-			$xml .= "\t\t\t<image:license>" . esc_xml( $image->license() ) . "</image:license>\n";
-		}
-
 		$xml .= "\t\t</image:image>\n";
 
 		return $xml;

--- a/tests/ImageEntryTest.php
+++ b/tests/ImageEntryTest.php
@@ -14,39 +14,21 @@ use InvalidArgumentException;
 
 /**
  * Unit Tests for ImageEntry.
+ *
+ * Per Google's Image Sitemap specification, only the loc (URL) element is required.
+ * Other elements (caption, geo_location, title, license) have been deprecated by Google.
+ *
+ * @see https://developers.google.com/search/docs/crawling-indexing/sitemaps/image-sitemaps
  */
 class ImageEntryTest extends TestCase {
 
 	/**
-	 * Test that ImageEntry can be created with valid data.
+	 * Test that ImageEntry can be created with a valid URL.
 	 */
-	public function test_create_image_entry_with_valid_data(): void {
-		$image = new ImageEntry(
-			'https://example.com/image.jpg',
-			'Test caption',
-			'New York, NY',
-			'Test Image Title',
-			'https://creativecommons.org/licenses/by/4.0/'
-		);
-
-		$this->assertEquals( 'https://example.com/image.jpg', $image->loc() );
-		$this->assertEquals( 'Test caption', $image->caption() );
-		$this->assertEquals( 'New York, NY', $image->geo_location() );
-		$this->assertEquals( 'Test Image Title', $image->title() );
-		$this->assertEquals( 'https://creativecommons.org/licenses/by/4.0/', $image->license() );
-	}
-
-	/**
-	 * Test that ImageEntry can be created with minimal data.
-	 */
-	public function test_create_image_entry_with_minimal_data(): void {
+	public function test_create_image_entry_with_valid_url(): void {
 		$image = new ImageEntry( 'https://example.com/image.jpg' );
 
 		$this->assertEquals( 'https://example.com/image.jpg', $image->loc() );
-		$this->assertNull( $image->caption() );
-		$this->assertNull( $image->geo_location() );
-		$this->assertNull( $image->title() );
-		$this->assertNull( $image->license() );
 	}
 
 	/**
@@ -74,7 +56,7 @@ class ImageEntryTest extends TestCase {
 	 */
 	public function test_create_image_entry_with_url_too_long_throws_exception(): void {
 		$long_url = 'https://example.com/' . str_repeat( 'a', 2048 );
-		
+
 		$this->expectException( InvalidArgumentException::class );
 		$this->expectExceptionMessage( 'Image URL cannot exceed 2048 characters.' );
 
@@ -82,54 +64,9 @@ class ImageEntryTest extends TestCase {
 	}
 
 	/**
-	 * Test that ImageEntry throws exception for caption that is too long.
-	 */
-	public function test_create_image_entry_with_caption_too_long_throws_exception(): void {
-		$long_caption = str_repeat( 'a', 2049 );
-		
-		$this->expectException( InvalidArgumentException::class );
-		$this->expectExceptionMessage( 'Image caption cannot exceed 2048 characters.' );
-
-		new ImageEntry( 'https://example.com/image.jpg', $long_caption );
-	}
-
-	/**
-	 * Test that ImageEntry throws exception for invalid license URL.
-	 */
-	public function test_create_image_entry_with_invalid_license_throws_exception(): void {
-		$this->expectException( InvalidArgumentException::class );
-		$this->expectExceptionMessage( 'License URL must be a valid URL.' );
-
-		new ImageEntry( 'https://example.com/image.jpg', null, null, null, 'not-a-url' );
-	}
-
-	/**
 	 * Test that ImageEntry to_array method works correctly.
 	 */
 	public function test_image_entry_to_array(): void {
-		$image = new ImageEntry(
-			'https://example.com/image.jpg',
-			'Test caption',
-			'New York, NY',
-			'Test Image Title',
-			'https://creativecommons.org/licenses/by/4.0/'
-		);
-
-		$expected = array(
-			'loc'          => 'https://example.com/image.jpg',
-			'caption'      => 'Test caption',
-			'geo_location' => 'New York, NY',
-			'title'        => 'Test Image Title',
-			'license'      => 'https://creativecommons.org/licenses/by/4.0/',
-		);
-
-		$this->assertEquals( $expected, $image->to_array() );
-	}
-
-	/**
-	 * Test that ImageEntry to_array method works with minimal data.
-	 */
-	public function test_image_entry_to_array_with_minimal_data(): void {
 		$image = new ImageEntry( 'https://example.com/image.jpg' );
 
 		$expected = array(
@@ -143,25 +80,30 @@ class ImageEntryTest extends TestCase {
 	 * Test that ImageEntry equals method works correctly.
 	 */
 	public function test_image_entry_equals(): void {
-		$image1 = new ImageEntry(
-			'https://example.com/image.jpg',
-			'Test caption',
-			'New York, NY',
-			'Test Image Title',
-			'https://creativecommons.org/licenses/by/4.0/'
-		);
-
-		$image2 = new ImageEntry(
-			'https://example.com/image.jpg',
-			'Test caption',
-			'New York, NY',
-			'Test Image Title',
-			'https://creativecommons.org/licenses/by/4.0/'
-		);
-
+		$image1 = new ImageEntry( 'https://example.com/image.jpg' );
+		$image2 = new ImageEntry( 'https://example.com/image.jpg' );
 		$image3 = new ImageEntry( 'https://example.com/different.jpg' );
 
 		$this->assertTrue( $image1->equals( $image2 ) );
 		$this->assertFalse( $image1->equals( $image3 ) );
+	}
+
+	/**
+	 * Test that ImageEntry accepts valid URL schemes.
+	 *
+	 * @dataProvider valid_url_schemes_data_provider
+	 */
+	public function test_image_entry_accepts_valid_url_schemes( string $url ): void {
+		$image = new ImageEntry( $url );
+
+		$this->assertEquals( $url, $image->loc() );
+	}
+
+	/**
+	 * Data provider for valid URL schemes.
+	 */
+	public function valid_url_schemes_data_provider(): iterable {
+		yield 'https' => array( 'url' => 'https://example.com/image.jpg' );
+		yield 'http' => array( 'url' => 'http://example.com/image.jpg' );
 	}
 }

--- a/tests/SitemapXmlFormatterWithImagesTest.php
+++ b/tests/SitemapXmlFormatterWithImagesTest.php
@@ -16,6 +16,11 @@ use Automattic\MSM_Sitemap\Infrastructure\Formatters\SitemapXmlFormatter;
 
 /**
  * Unit Tests for SitemapXmlFormatter with images.
+ *
+ * Per Google's Image Sitemap specification, only the loc element is required.
+ * Other elements (caption, geo_location, title, license) have been deprecated by Google.
+ *
+ * @see https://developers.google.com/search/docs/crawling-indexing/sitemaps/image-sitemaps
  */
 class SitemapXmlFormatterWithImagesTest extends TestCase {
 
@@ -25,17 +30,11 @@ class SitemapXmlFormatterWithImagesTest extends TestCase {
 	public function test_format_includes_image_elements(): void {
 		$formatter = new SitemapXmlFormatter();
 		$content   = new SitemapContent();
-		
-		// Create an image entry
-		$image = new ImageEntry(
-			'https://example.com/image.jpg',
-			'Test image caption',
-			'New York, NY',
-			'Test Image Title',
-			'https://creativecommons.org/licenses/by/4.0/'
-		);
-		
-		// Create a URL entry with images
+
+		// Create an image entry (only loc is supported per Google spec).
+		$image = new ImageEntry( 'https://example.com/image.jpg' );
+
+		// Create a URL entry with images.
 		$entry = new UrlEntry(
 			'https://example.com/test-post',
 			'2024-01-15T00:00:00+00:00',
@@ -43,19 +42,21 @@ class SitemapXmlFormatterWithImagesTest extends TestCase {
 			0.8,
 			array( $image )
 		);
-		
+
 		$content = $content->add( $entry );
 
 		$xml = $formatter->format( $content );
 
-		// Check that image elements are included
+		// Check that image elements are included.
 		$this->assertStringContainsString( '<image:image>', $xml );
 		$this->assertStringContainsString( '<image:loc>https://example.com/image.jpg</image:loc>', $xml );
-		$this->assertStringContainsString( '<image:title>Test Image Title</image:title>', $xml );
-		$this->assertStringContainsString( '<image:caption>Test image caption</image:caption>', $xml );
-		$this->assertStringContainsString( '<image:geo_location>New York, NY</image:geo_location>', $xml );
-		$this->assertStringContainsString( '<image:license>https://creativecommons.org/licenses/by/4.0/</image:license>', $xml );
 		$this->assertStringContainsString( '</image:image>', $xml );
+
+		// Check that deprecated elements are NOT included.
+		$this->assertStringNotContainsString( '<image:title>', $xml );
+		$this->assertStringNotContainsString( '<image:caption>', $xml );
+		$this->assertStringNotContainsString( '<image:geo_location>', $xml );
+		$this->assertStringNotContainsString( '<image:license>', $xml );
 	}
 
 	/**
@@ -64,24 +65,24 @@ class SitemapXmlFormatterWithImagesTest extends TestCase {
 	public function test_format_handles_urls_without_images(): void {
 		$formatter = new SitemapXmlFormatter();
 		$content   = new SitemapContent();
-		
-		// Create a URL entry without images
+
+		// Create a URL entry without images.
 		$entry = new UrlEntry(
 			'https://example.com/test-post',
 			'2024-01-15T00:00:00+00:00',
 			'daily',
 			0.8
 		);
-		
+
 		$content = $content->add( $entry );
 
 		$xml = $formatter->format( $content );
 
-		// Check that image elements are not included
+		// Check that image elements are not included.
 		$this->assertStringNotContainsString( '<image:image>', $xml );
 		$this->assertStringNotContainsString( '</image:image>', $xml );
-		
-		// Check that URL elements are still present
+
+		// Check that URL elements are still present.
 		$this->assertStringContainsString( '<url>', $xml );
 		$this->assertStringContainsString( '</url>', $xml );
 		$this->assertStringContainsString( '<loc>https://example.com/test-post</loc>', $xml );
@@ -93,12 +94,12 @@ class SitemapXmlFormatterWithImagesTest extends TestCase {
 	public function test_format_handles_multiple_images_per_url(): void {
 		$formatter = new SitemapXmlFormatter();
 		$content   = new SitemapContent();
-		
-		// Create multiple image entries
-		$image1 = new ImageEntry( 'https://example.com/image1.jpg', 'First image' );
-		$image2 = new ImageEntry( 'https://example.com/image2.jpg', 'Second image' );
-		
-		// Create a URL entry with multiple images
+
+		// Create multiple image entries (only loc is supported per Google spec).
+		$image1 = new ImageEntry( 'https://example.com/image1.jpg' );
+		$image2 = new ImageEntry( 'https://example.com/image2.jpg' );
+
+		// Create a URL entry with multiple images.
 		$entry = new UrlEntry(
 			'https://example.com/test-post',
 			'2024-01-15T00:00:00+00:00',
@@ -106,18 +107,16 @@ class SitemapXmlFormatterWithImagesTest extends TestCase {
 			0.8,
 			array( $image1, $image2 )
 		);
-		
+
 		$content = $content->add( $entry );
 
 		$xml = $formatter->format( $content );
 
-		// Check that both image elements are included
+		// Check that both image elements are included.
 		$this->assertStringContainsString( '<image:loc>https://example.com/image1.jpg</image:loc>', $xml );
 		$this->assertStringContainsString( '<image:loc>https://example.com/image2.jpg</image:loc>', $xml );
-		$this->assertStringContainsString( '<image:caption>First image</image:caption>', $xml );
-		$this->assertStringContainsString( '<image:caption>Second image</image:caption>', $xml );
-		
-		// Count image elements
+
+		// Count image elements.
 		$image_count = substr_count( $xml, '<image:image>' );
 		$this->assertEquals( 2, $image_count );
 	}
@@ -128,11 +127,11 @@ class SitemapXmlFormatterWithImagesTest extends TestCase {
 	public function test_format_produces_valid_xml_structure_with_images(): void {
 		$formatter = new SitemapXmlFormatter();
 		$content   = new SitemapContent();
-		
-		// Create an image entry
-		$image = new ImageEntry( 'https://example.com/image.jpg', 'Test image' );
-		
-		// Create a URL entry with image
+
+		// Create an image entry.
+		$image = new ImageEntry( 'https://example.com/image.jpg' );
+
+		// Create a URL entry with image.
 		$entry = new UrlEntry(
 			'https://example.com/test-post',
 			'2024-01-15T00:00:00+00:00',
@@ -140,19 +139,19 @@ class SitemapXmlFormatterWithImagesTest extends TestCase {
 			0.8,
 			array( $image )
 		);
-		
+
 		$content = $content->add( $entry );
 
 		$xml = $formatter->format( $content );
 
-		// Check XML structure
+		// Check XML structure.
 		$this->assertStringContainsString( '<?xml version="1.0" encoding="UTF-8"?>', $xml );
 		$this->assertStringContainsString( '<urlset', $xml );
 		$this->assertStringContainsString( '</urlset>', $xml );
 		$this->assertStringContainsString( '<url>', $xml );
 		$this->assertStringContainsString( '</url>', $xml );
-		
-		// Check that image namespace is included
+
+		// Check that image namespace is included.
 		$this->assertStringContainsString( 'xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"', $xml );
 	}
 }

--- a/tests/UrlEntryTest.php
+++ b/tests/UrlEntryTest.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace Automattic\MSM_Sitemap\Tests;
 
+use Automattic\MSM_Sitemap\Domain\ValueObjects\ImageEntry;
 use Automattic\MSM_Sitemap\Domain\ValueObjects\UrlEntry;
 
 /**
@@ -323,5 +324,70 @@ class UrlEntryTest extends TestCase {
 		yield 'date only' => array( 'lastmod' => '2024-01-15' );
 		yield 'ISO 8601 with timezone' => array( 'lastmod' => '2024-01-15T10:30:00+00:00' );
 		yield 'ISO 8601 with negative timezone' => array( 'lastmod' => '2024-01-15T10:30:00-05:00' );
+	}
+
+	/**
+	 * Test that UrlEntry allows up to 1000 images per URL.
+	 */
+	public function test_url_entry_allows_1000_images(): void {
+		$images = array();
+		for ( $i = 1; $i <= 1000; $i++ ) {
+			$images[] = new ImageEntry( 'https://example.com/image' . $i . '.jpg' );
+		}
+
+		$url_entry = new UrlEntry(
+			'https://example.com/post/',
+			null,
+			null,
+			null,
+			$images
+		);
+
+		$this->assertEquals( 1000, $url_entry->image_count() );
+	}
+
+	/**
+	 * Test that UrlEntry throws exception when exceeding 1000 images per URL.
+	 *
+	 * Per Google's Image Sitemap specification, a maximum of 1000 images
+	 * can be included per URL.
+	 *
+	 * @see https://developers.google.com/search/docs/crawling-indexing/sitemaps/image-sitemaps
+	 */
+	public function test_url_entry_throws_exception_when_exceeding_1000_images(): void {
+		$images = array();
+		for ( $i = 1; $i <= 1001; $i++ ) {
+			$images[] = new ImageEntry( 'https://example.com/image' . $i . '.jpg' );
+		}
+
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Too many images: 1001 provided, maximum is 1000 per URL.' );
+
+		new UrlEntry(
+			'https://example.com/post/',
+			null,
+			null,
+			null,
+			$images
+		);
+	}
+
+	/**
+	 * Test creating URL entry with images.
+	 */
+	public function test_create_url_entry_with_images(): void {
+		$image = new ImageEntry( 'https://example.com/image.jpg' );
+
+		$url_entry = new UrlEntry(
+			'https://example.com/post/',
+			null,
+			null,
+			null,
+			array( $image )
+		);
+
+		$this->assertTrue( $url_entry->has_images() );
+		$this->assertEquals( 1, $url_entry->image_count() );
+		$this->assertCount( 1, $url_entry->images() );
 	}
 } 


### PR DESCRIPTION
## Problem

Google's Image Sitemap specification has evolved since this plugin's initial implementation. The current implementation outputs several deprecated image properties that are no longer recognised by Google Search Console and do not contribute to search optimisation. Additionally, the implementation lacked enforcement of Google's documented limit of 1000 images per URL, which could result in sitemaps that don't comply with the specification.

This misalignment with the current specification means we're generating unnecessary XML data whilst potentially creating non-compliant sitemaps when pages contain many images.

## Solution

This change brings the image sitemap implementation into full compliance with Google's current Image Sitemap specification (https://developers.google.com/search/docs/crawling-indexing/sitemaps/image-sitemaps).

The implementation now:
- Outputs only the required `<image:loc>` element, removing the deprecated `<image:caption>`, `<image:geo_location>`, `<image:title>`, and `<image:license>` elements that Google no longer processes
- Enforces Google's documented limit of 1000 images per URL through validation in the `UrlEntry` value object
- Simplifies the `ImageEntry` value object to store only the image URL, reducing memory overhead
- Updates the `ImageEntryFactory` to extract only the image URL from attachment data

The changes significantly reduce the size of generated sitemaps whilst ensuring compliance with the specification. All 582 tests pass with the updated implementation.