### PR TITLE
chore: add export-ignore for dev files in release archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,14 +1,26 @@
 # Exclude from release archives
-/.github/         export-ignore
-/.wordpress-org/  export-ignore
-/tests/           export-ignore
-/.distignore      export-ignore
-/.editorconfig    export-ignore
-/.gitattributes   export-ignore
-/.gitignore       export-ignore
-/.phpcs.xml.dist  export-ignore
-/CHANGELOG.md     export-ignore
-/phpunit.xml.dist export-ignore
+/.github/              export-ignore
+/.wordpress-org/       export-ignore
+/bin/                  export-ignore
+/node_modules/         export-ignore
+/tests/                export-ignore
+/vendor/               export-ignore
+/.distignore           export-ignore
+/.editorconfig         export-ignore
+/.gitattributes        export-ignore
+/.gitignore            export-ignore
+/.gitmodules           export-ignore
+/.npmrc                export-ignore
+/.phpcs.xml.dist       export-ignore
+/.wp-env.json          export-ignore
+/.wp-env.override.json export-ignore
+/CHANGELOG.md          export-ignore
+/composer.json         export-ignore
+/composer.lock         export-ignore
+/DEVELOPERS.md         export-ignore
+/package.json          export-ignore
+/package-lock.json     export-ignore
+/phpunit.xml.dist      export-ignore
 
 # Auto detect text files and perform LF normalization
 * text=auto


### PR DESCRIPTION
## Summary

- Updates `.gitattributes` so GitHub's "Source code (zip)" excludes development files from release archives
- Adds export-ignore for: composer.json, composer.lock, package.json, package-lock.json, DEVELOPERS.md, .npmrc, .wp-env.json, and other dev files

This ensures future releases (1.5.6+) have clean zip files without development dependencies.

## Test plan

- [ ] Create a release and verify the "Source code (zip)" excludes the listed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)