### PR TITLE
chore: enable merged coverage reporting for unit and integration tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,110 @@
+name: Code Coverage
+
+on:
+  pull_request:
+    paths:
+      - '**.php'
+      - 'composer.json'
+      - 'phpunit.xml.dist'
+      - '.github/workflows/coverage.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-coverage:
+    name: Unit Test Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP with PCOV
+        uses: shivammathur/setup-php@cf4cade2721270509d5b1c766ab3549210a39a2a # 2.32.0
+        with:
+          php-version: '8.3'
+          coverage: pcov
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@57532f8be5bda426838819c5ee9afb8af389d51a # 3.0.0
+
+      - name: Run unit tests with coverage
+        run: composer coverage:unit
+
+      - name: Generate text coverage report
+        run: |
+          ./vendor/bin/phpcov merge coverage/ --text coverage/unit-summary.txt || true
+          echo "## Unit Test Coverage" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat coverage/unit-summary.txt >> $GITHUB_STEP_SUMMARY 2>/dev/null || echo "Coverage summary not available" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: unit-coverage
+          path: coverage/
+          retention-days: 7
+
+  integration-coverage:
+    name: Integration Test Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install Node.js dependencies
+        run: npm ci
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@cf4cade2721270509d5b1c766ab3549210a39a2a # 2.32.0
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@57532f8be5bda426838819c5ee9afb8af389d51a # 3.0.0
+
+      - name: Start wp-env with Xdebug coverage
+        run: npm run wp-env start -- --xdebug=coverage
+
+      - name: Run integration tests with coverage
+        run: composer coverage:integration
+
+      - name: Generate coverage summary
+        run: |
+          echo "## Integration Test Coverage" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          if [ -f coverage/integration.cov ]; then
+            echo "Integration coverage generated successfully" >> $GITHUB_STEP_SUMMARY
+            ls -lh coverage/integration.cov >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Integration coverage file not found" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: integration-coverage
+          path: coverage/
+          retention-days: 7

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
 		"ergebnis/phpunit-slow-test-detector": "^2.19",
 		"php-parallel-lint/php-parallel-lint": "^1.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
+		"phpunit/phpcov": "^8.2",
 		"phpunit/phpunit": "^9",
 		"wp-coding-standards/wpcs": "^3.0",
 		"yoast/wp-test-utils": "^1.2.0"
@@ -48,8 +49,13 @@
 	},
 	"scripts": {
 		"coverage": [
-			"@php ./vendor/bin/phpunit --coverage-html ./.phpunit.cache/code-coverage-html"
+			"@coverage:unit",
+			"@coverage:integration",
+			"@coverage:merge"
 		],
+		"coverage:unit": "@php ./vendor/bin/phpunit --testsuite unit --coverage-php coverage/unit.cov",
+		"coverage:integration": "npx wp-env run tests-cli --env-cwd=wp-content/plugins/msm-sitemap ./vendor/bin/phpunit --testsuite integration --coverage-php coverage/integration.cov",
+		"coverage:merge": "@php ./vendor/bin/phpcov merge coverage/ --clover coverage/clover.xml --html coverage/html",
 		"cs": [
 			"@php ./vendor/bin/phpcs -q"
 		],
@@ -68,7 +74,10 @@
 		"test:integration-ms": "npx wp-env run tests-cli --env-cwd=wp-content/plugins/msm-sitemap /bin/bash -c 'WP_MULTISITE=1 ./vendor/bin/phpunit --testsuite integration --no-coverage'"
 	},
 	"scripts-descriptions": {
-		"coverage": "Run tests with code coverage reporting",
+		"coverage": "Run all tests with merged code coverage (for CI)",
+		"coverage:unit": "Run unit tests with coverage output",
+		"coverage:integration": "Run integration tests with coverage output via wp-env",
+		"coverage:merge": "Merge coverage reports into combined HTML and Clover XML",
 		"cs": "Run PHP Code Sniffer",
 		"cs-fix": "Run PHP Code Sniffer and fix violations",
 		"i18n": "Generate a POT file for translation",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -33,7 +33,7 @@
     </groups>
 
     <coverage cacheDirectory=".phpunit.cache/code-coverage"
-              processUncoveredFiles="true">
+              processUncoveredFiles="false">
         <include>
 			<file>msm-sitemap.php</file>
 			<directory>templates</directory>


### PR DESCRIPTION
## Summary
- Add `phpunit/phpcov` dependency for merging coverage reports
- Add composer scripts for coverage workflow (`coverage:unit`, `coverage:integration`, `coverage:merge`, `coverage`)
- Set `processUncoveredFiles="false"` to avoid class/function redeclaration errors

This enables combined code coverage reporting from both unit and integration tests using phpcov to merge the results.

## Test plan
- [ ] Verify existing CI workflows pass (unit tests, integration tests, CS/lint)
- [ ] Run `composer coverage:unit` locally with Xdebug/PCOV enabled
- [ ] Run `composer coverage:integration` with `wp-env start --xdebug=coverage`
- [ ] Verify `.cov` files are generated in `coverage/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)