### PR TITLE
chore: raise minimum PHP version to 8.2 for 2.x release

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -37,7 +37,7 @@ jobs:
         include:
           # Check lowest supported WP version, with the lowest supported PHP.
           - wordpress: '6.4'
-            php: '7.4'
+            php: '8.2'
           # Check latest WP with the latest PHP.
           - wordpress: 'master'
             php: 'latest'

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -35,10 +35,9 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - '7.4'
-          - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
 
     steps:
       - name: Checkout code

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -5,7 +5,7 @@
   "mappings": {
     "wp-content/mu-plugins": "./mu-plugins"
   },
-  "phpVersion": "8.1",
+  "phpVersion": "8.2",
   "config": {
     "WP_DEBUG": true,
     "WP_DEBUG_LOG": true,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to MSM Sitemap! This document provid
 
 ## Requirements
 
-* **Minimum Requirements:** WordPress 5.9+, PHP 7.4+
+* **Minimum Requirements:** WordPress 6.4+, PHP 8.2+
 * **Coding Standards:** Follows [WordPress Coding Standards](https://github.com/WordPress/WordPress-Coding-Standards) and [PSR-12](https://www.php-fig.org/psr/psr-12/)
 
 ## Development Setup

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Stable tag: 1.5.5  
 Requires at least: 6.4  
 Tested up to: 6.9  
-Requires PHP: 7.4  
+Requires PHP: 8.2  
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  
 Tags: sitemap, xml, seo, performance, multisite  

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"source": "https://github.com/Automattic/msm-sitemap"
 	},
 	"require": {
-		"php": ">=7.4",
+		"php": ">=8.2",
 		"composer/installers": "^1.0 || ^2.0"
 	},
 	"require-dev": {

--- a/msm-sitemap.php
+++ b/msm-sitemap.php
@@ -13,7 +13,7 @@
  * Description:       Smart date-based sitemaps with automatic generation, detailed monitoring, and enterprise-ready architecture.
  * Version:           2.0.0-dev
  * Requires at least: 6.4
- * Requires PHP:      7.4
+ * Requires PHP:      8.2
  * Author:            Metro.co.uk, MAKE, Alley Interactive, WordPress VIP.
  * Text Domain:       msm-sitemap
  * License:           GPL-2.0-or-later


### PR DESCRIPTION
## Summary
- Update minimum PHP version from 7.4 to 8.2 for the 2.x release
- Update CI workflows to test PHP 8.2, 8.3, and 8.4
- Update documentation to reflect new requirements

## Changes
| File | Update |
|------|--------|
| `composer.json` | `"php": ">=8.2"` |
| `msm-sitemap.php` | Plugin header `Requires PHP: 8.2` |
| `.wp-env.json` | `"phpVersion": "8.2"` |
| `README.md` | `Requires PHP: 8.2` |
| `CONTRIBUTING.md` | `PHP 8.2+` |
| `unit.yml` | Matrix: 8.2, 8.3, 8.4 |
| `integration.yml` | Lowest: PHP 8.2 |

## Test plan
- [ ] CI passes on PHP 8.2, 8.3, 8.4
- [ ] No PHP 7.x compatibility code remains in use

🤖 Generated with [Claude Code](https://claude.com/claude-code)