### PR TITLE
Use createStub() for test doubles without expectations

### DIFF
--- a/tests/Integration/Application/Services/SitemapCleanupServiceTest.php
+++ b/tests/Integration/Application/Services/SitemapCleanupServiceTest.php
@@ -35,7 +35,7 @@ class SitemapCleanupServiceTest extends TestCase {
 		update_post_meta( $post_id, 'msm_indexed_url_count', 5 );
 
 		$repository      = new SitemapPostRepository();
-		$post_repository = $this->createMock( PostRepository::class );
+		$post_repository = $this->createStub( PostRepository::class );
 		$post_repository->method( 'date_range_has_posts' )
 			->with( $date, $date )
 			->willReturn( null );
@@ -72,7 +72,7 @@ class SitemapCleanupServiceTest extends TestCase {
 		update_post_meta( $post_id, 'msm_indexed_url_count', 5 );
 
 		$repository      = new SitemapPostRepository();
-		$post_repository = $this->createMock( PostRepository::class );
+		$post_repository = $this->createStub( PostRepository::class );
 		$post_repository->method( 'date_range_has_posts' )
 			->with( $date, $date )
 			->willReturn( 123 );
@@ -120,7 +120,7 @@ class SitemapCleanupServiceTest extends TestCase {
 		update_post_meta( $post_without_posts, 'msm_indexed_url_count', 3 );
 
 		$repository      = new SitemapPostRepository();
-		$post_repository = $this->createMock( PostRepository::class );
+		$post_repository = $this->createStub( PostRepository::class );
 		$post_repository->method( 'get_post_ids_for_date' )
 			->willReturnMap(
 				array(

--- a/tests/Integration/Application/Services/SitemapGenerationServiceTest.php
+++ b/tests/Integration/Application/Services/SitemapGenerationServiceTest.php
@@ -26,12 +26,12 @@ class SitemapGenerationServiceTest extends TestCase {
 	 * Test creating a sitemap for a specific date.
 	 */
 	public function test_create_for_date_success(): void {
-		$generator     = $this->createMock( SitemapGenerator::class );
-		$repository    = $this->createMock( SitemapRepositoryInterface::class );
+		$generator     = $this->createStub( SitemapGenerator::class );
+		$repository    = $this->createStub( SitemapRepositoryInterface::class );
 		$query_service = new SitemapQueryService();
 
 		// Mock generator to return content
-		$content = $this->createMock( \Automattic\MSM_Sitemap\Domain\ValueObjects\SitemapContent::class );
+		$content = $this->createStub( \Automattic\MSM_Sitemap\Domain\ValueObjects\SitemapContent::class );
 		$content->method( 'count' )->willReturn( 5 );
 		$generator->method( 'generate_sitemap_for_date' )->willReturn( $content );
 
@@ -52,8 +52,8 @@ class SitemapGenerationServiceTest extends TestCase {
 	 * Test creating a sitemap when one already exists.
 	 */
 	public function test_create_for_date_already_exists(): void {
-		$generator     = $this->createMock( SitemapGenerator::class );
-		$repository    = $this->createMock( SitemapRepositoryInterface::class );
+		$generator     = $this->createStub( SitemapGenerator::class );
+		$repository    = $this->createStub( SitemapRepositoryInterface::class );
 		$query_service = new SitemapQueryService();
 
 		// Mock repository to return existing sitemap
@@ -71,12 +71,12 @@ class SitemapGenerationServiceTest extends TestCase {
 	 * Test creating a sitemap when no content is found.
 	 */
 	public function test_create_for_date_no_content(): void {
-		$generator     = $this->createMock( SitemapGenerator::class );
-		$repository    = $this->createMock( SitemapRepositoryInterface::class );
+		$generator     = $this->createStub( SitemapGenerator::class );
+		$repository    = $this->createStub( SitemapRepositoryInterface::class );
 		$query_service = new SitemapQueryService();
 
 		// Mock generator to return empty content
-		$content = $this->createMock( \Automattic\MSM_Sitemap\Domain\ValueObjects\SitemapContent::class );
+		$content = $this->createStub( \Automattic\MSM_Sitemap\Domain\ValueObjects\SitemapContent::class );
 		$content->method( 'count' )->willReturn( 0 );
 		$generator->method( 'generate_sitemap_for_date' )->willReturn( $content );
 
@@ -96,12 +96,12 @@ class SitemapGenerationServiceTest extends TestCase {
 	 * Test generating sitemaps for date queries.
 	 */
 	public function test_generate_for_date_queries_success(): void {
-		$generator     = $this->createMock( SitemapGenerator::class );
-		$repository    = $this->createMock( SitemapRepositoryInterface::class );
-		$query_service = $this->createMock( SitemapQueryService::class );
+		$generator     = $this->createStub( SitemapGenerator::class );
+		$repository    = $this->createStub( SitemapRepositoryInterface::class );
+		$query_service = $this->createStub( SitemapQueryService::class );
 
 		// Mock generator to return content
-		$content = $this->createMock( \Automattic\MSM_Sitemap\Domain\ValueObjects\SitemapContent::class );
+		$content = $this->createStub( \Automattic\MSM_Sitemap\Domain\ValueObjects\SitemapContent::class );
 		$content->method( 'count' )->willReturn( 3 );
 		$generator->method( 'generate_sitemap_for_date' )->willReturn( $content );
 
@@ -137,8 +137,8 @@ class SitemapGenerationServiceTest extends TestCase {
 	 * Test generating sitemaps with empty queries.
 	 */
 	public function test_generate_for_date_queries_empty(): void {
-		$generator     = $this->createMock( SitemapGenerator::class );
-		$repository    = $this->createMock( SitemapRepositoryInterface::class );
+		$generator     = $this->createStub( SitemapGenerator::class );
+		$repository    = $this->createStub( SitemapRepositoryInterface::class );
 		$query_service = new SitemapQueryService();
 
 		$service = new SitemapGenerationService( $generator, $repository, $query_service );

--- a/tests/Integration/CoreIntegrationTest.php
+++ b/tests/Integration/CoreIntegrationTest.php
@@ -52,7 +52,7 @@ class CoreIntegrationTest extends TestCase {
 	 */
 	public function test_disable_core_providers(): void {
 		// Mock WP_Sitemaps instance
-		$wp_sitemaps = $this->createMock( WP_Sitemaps::class );
+		$wp_sitemaps = $this->createStub( WP_Sitemaps::class );
 		$registry    = $this->createMock( \WP_Sitemaps_Registry::class );
 
 		// Set up expectations
@@ -74,9 +74,9 @@ class CoreIntegrationTest extends TestCase {
 	 * Test that disabled providers return empty results.
 	 */
 	public function test_disabled_providers_return_empty_results(): void {
-		// Create a mock WP_Sitemaps instance
-		$wp_sitemaps = $this->createMock( WP_Sitemaps::class );
-		$registry    = $this->createMock( \WP_Sitemaps_Registry::class );
+		// Create a stub WP_Sitemaps instance
+		$wp_sitemaps = $this->createStub( WP_Sitemaps::class );
+		$registry    = $this->createStub( \WP_Sitemaps_Registry::class );
 
 		// Capture the provider instances
 		$captured_providers = array();

--- a/tests/Integration/Infrastructure/REST/REST_API_ControllerTest.php
+++ b/tests/Integration/Infrastructure/REST/REST_API_ControllerTest.php
@@ -170,7 +170,7 @@ class REST_API_ControllerTest extends WP_Test_REST_TestCase {
 		$request->set_param( 'date', '2024-01-15' );
 
 		// Mock the sitemap service to return data
-		$sitemap_service = $this->createMock( SitemapService::class );
+		$sitemap_service = $this->createStub( SitemapService::class );
 		$sitemap_service->method( 'get_sitemap_data' )
 			->with( '2024-01-15' )
 			->willReturn(
@@ -183,7 +183,7 @@ class REST_API_ControllerTest extends WP_Test_REST_TestCase {
 
 		$controller = new SitemapsController(
 			$sitemap_service,
-			$this->createMock( GenerateSitemapUseCase::class )
+			$this->createStub( GenerateSitemapUseCase::class )
 		);
 
 		$response = $controller->get_sitemap( $request );
@@ -205,13 +205,13 @@ class REST_API_ControllerTest extends WP_Test_REST_TestCase {
 		$request = new WP_REST_Request( 'GET', '/msm-sitemap/v1/sitemaps/invalid-date' );
 		$request->set_param( 'date', 'invalid-date' );
 
-		$sitemap_service = $this->createMock( SitemapService::class );
+		$sitemap_service = $this->createStub( SitemapService::class );
 		$sitemap_service->method( 'get_sitemap_data' )
 			->willReturn( null );
 
 		$controller = new SitemapsController(
 			$sitemap_service,
-			$this->createMock( GenerateSitemapUseCase::class )
+			$this->createStub( GenerateSitemapUseCase::class )
 		);
 
 		$response = $controller->get_sitemap( $request );
@@ -230,14 +230,14 @@ class REST_API_ControllerTest extends WP_Test_REST_TestCase {
 		$request->set_param( 'date', '2024-01-15' );
 
 		// Mock the sitemap service to return null (not found)
-		$sitemap_service = $this->createMock( SitemapService::class );
+		$sitemap_service = $this->createStub( SitemapService::class );
 		$sitemap_service->method( 'get_sitemap_data' )
 			->with( '2024-01-15' )
 			->willReturn( null );
 
 		$controller = new SitemapsController(
 			$sitemap_service,
-			$this->createMock( GenerateSitemapUseCase::class )
+			$this->createStub( GenerateSitemapUseCase::class )
 		);
 
 		$response = $controller->get_sitemap( $request );
@@ -254,7 +254,7 @@ class REST_API_ControllerTest extends WP_Test_REST_TestCase {
 		$request = new WP_REST_Request( 'GET', '/msm-sitemap/v1/missing' );
 
 		// Mock the detection service
-		$missing_detection_service = $this->createMock( MissingSitemapDetectionService::class );
+		$missing_detection_service = $this->createStub( MissingSitemapDetectionService::class );
 		$missing_detection_service->method( 'get_missing_sitemaps' )
 			->willReturn(
 				array(
@@ -271,16 +271,16 @@ class REST_API_ControllerTest extends WP_Test_REST_TestCase {
 			);
 
 		// Mock the cron management service
-		$cron_management_service = $this->createMock( CronManagementService::class );
+		$cron_management_service = $this->createStub( CronManagementService::class );
 		$cron_management_service->method( 'get_cron_status' )
 			->willReturn( array( 'enabled' => true ) );
 
 		$controller = new GenerationController(
 			$cron_management_service,
 			$missing_detection_service,
-			$this->createMock( IncrementalGenerationService::class ),
-			$this->createMock( SitemapGenerator::class ),
-			$this->createMock( SettingsService::class )
+			$this->createStub( IncrementalGenerationService::class ),
+			$this->createStub( SitemapGenerator::class ),
+			$this->createStub( SettingsService::class )
 		);
 
 		$response = $controller->get_missing_sitemaps( $request );
@@ -305,7 +305,7 @@ class REST_API_ControllerTest extends WP_Test_REST_TestCase {
 		$request = new WP_REST_Request( 'GET', '/msm-sitemap/v1/missing' );
 
 		// Mock the detection service with no missing sitemaps
-		$missing_detection_service = $this->createMock( MissingSitemapDetectionService::class );
+		$missing_detection_service = $this->createStub( MissingSitemapDetectionService::class );
 		$missing_detection_service->method( 'get_missing_sitemaps' )
 			->willReturn(
 				array(
@@ -322,16 +322,16 @@ class REST_API_ControllerTest extends WP_Test_REST_TestCase {
 			);
 
 		// Mock the cron management service
-		$cron_management_service = $this->createMock( CronManagementService::class );
+		$cron_management_service = $this->createStub( CronManagementService::class );
 		$cron_management_service->method( 'get_cron_status' )
 			->willReturn( array( 'enabled' => true ) );
 
 		$controller = new GenerationController(
 			$cron_management_service,
 			$missing_detection_service,
-			$this->createMock( IncrementalGenerationService::class ),
-			$this->createMock( SitemapGenerator::class ),
-			$this->createMock( SettingsService::class )
+			$this->createStub( IncrementalGenerationService::class ),
+			$this->createStub( SitemapGenerator::class ),
+			$this->createStub( SettingsService::class )
 		);
 
 		$response = $controller->get_missing_sitemaps( $request );
@@ -349,7 +349,7 @@ class REST_API_ControllerTest extends WP_Test_REST_TestCase {
 		$request = new WP_REST_Request( 'POST', '/msm-sitemap/v1/generate-missing' );
 
 		// Mock the generation service
-		$incremental_generation_service = $this->createMock( IncrementalGenerationService::class );
+		$incremental_generation_service = $this->createStub( IncrementalGenerationService::class );
 		$incremental_generation_service->method( 'generate' )
 			->willReturn(
 				array(
@@ -361,11 +361,11 @@ class REST_API_ControllerTest extends WP_Test_REST_TestCase {
 			);
 
 		$controller = new GenerationController(
-			$this->createMock( CronManagementService::class ),
-			$this->createMock( MissingSitemapDetectionService::class ),
+			$this->createStub( CronManagementService::class ),
+			$this->createStub( MissingSitemapDetectionService::class ),
 			$incremental_generation_service,
-			$this->createMock( SitemapGenerator::class ),
-			$this->createMock( SettingsService::class )
+			$this->createStub( SitemapGenerator::class ),
+			$this->createStub( SettingsService::class )
 		);
 
 		$response = $controller->generate_missing_sitemaps( $request );
@@ -387,7 +387,7 @@ class REST_API_ControllerTest extends WP_Test_REST_TestCase {
 		$request = new WP_REST_Request( 'POST', '/msm-sitemap/v1/generate-missing' );
 
 		// Mock the generation service with failure
-		$incremental_generation_service = $this->createMock( IncrementalGenerationService::class );
+		$incremental_generation_service = $this->createStub( IncrementalGenerationService::class );
 		$incremental_generation_service->method( 'generate' )
 			->willReturn(
 				array(
@@ -397,11 +397,11 @@ class REST_API_ControllerTest extends WP_Test_REST_TestCase {
 			);
 
 		$controller = new GenerationController(
-			$this->createMock( CronManagementService::class ),
-			$this->createMock( MissingSitemapDetectionService::class ),
+			$this->createStub( CronManagementService::class ),
+			$this->createStub( MissingSitemapDetectionService::class ),
 			$incremental_generation_service,
-			$this->createMock( SitemapGenerator::class ),
-			$this->createMock( SettingsService::class )
+			$this->createStub( SitemapGenerator::class ),
+			$this->createStub( SettingsService::class )
 		);
 
 		$response = $controller->generate_missing_sitemaps( $request );

--- a/tests/Integration/Infrastructure/WordPress/Admin/UITest.php
+++ b/tests/Integration/Infrastructure/WordPress/Admin/UITest.php
@@ -30,15 +30,15 @@ class UITest extends TestCase {
 	 * Test that the UI class correctly receives and stores the plugin file path and version.
 	 */
 	public function test_ui_constructor_accepts_plugin_file_path_and_version(): void {
-		$cron_management           = $this->createMock( CronManagementService::class );
-		$missing_detection_service = $this->createMock( MissingSitemapDetectionService::class );
-		$stats_service             = $this->createMock( SitemapStatsService::class );
-		$settings_service          = $this->createMock( SettingsService::class );
-		$sitemap_repository        = $this->createMock( SitemapRepositoryInterface::class );
-		$taxonomy_sitemap_service  = $this->createMock( TaxonomySitemapService::class );
-		$author_sitemap_service    = $this->createMock( AuthorSitemapService::class );
-		$page_sitemap_service      = $this->createMock( PageSitemapService::class );
-		$action_handlers           = $this->createMock( ActionHandlers::class );
+		$cron_management           = $this->createStub( CronManagementService::class );
+		$missing_detection_service = $this->createStub( MissingSitemapDetectionService::class );
+		$stats_service             = $this->createStub( SitemapStatsService::class );
+		$settings_service          = $this->createStub( SettingsService::class );
+		$sitemap_repository        = $this->createStub( SitemapRepositoryInterface::class );
+		$taxonomy_sitemap_service  = $this->createStub( TaxonomySitemapService::class );
+		$author_sitemap_service    = $this->createStub( AuthorSitemapService::class );
+		$page_sitemap_service      = $this->createStub( PageSitemapService::class );
+		$action_handlers           = $this->createStub( ActionHandlers::class );
 		$plugin_file_path          = '/path/to/plugin/msm-sitemap.php';
 		$plugin_version            = '1.5.2';
 
@@ -71,15 +71,15 @@ class UITest extends TestCase {
 	 * Test that the UI class can be instantiated with plugin file path and version.
 	 */
 	public function test_ui_can_be_instantiated_with_plugin_file_path_and_version(): void {
-		$cron_management           = $this->createMock( CronManagementService::class );
-		$missing_detection_service = $this->createMock( MissingSitemapDetectionService::class );
-		$stats_service             = $this->createMock( SitemapStatsService::class );
-		$settings_service          = $this->createMock( SettingsService::class );
-		$sitemap_repository        = $this->createMock( SitemapRepositoryInterface::class );
-		$taxonomy_sitemap_service  = $this->createMock( TaxonomySitemapService::class );
-		$author_sitemap_service    = $this->createMock( AuthorSitemapService::class );
-		$page_sitemap_service      = $this->createMock( PageSitemapService::class );
-		$action_handlers           = $this->createMock( ActionHandlers::class );
+		$cron_management           = $this->createStub( CronManagementService::class );
+		$missing_detection_service = $this->createStub( MissingSitemapDetectionService::class );
+		$stats_service             = $this->createStub( SitemapStatsService::class );
+		$settings_service          = $this->createStub( SettingsService::class );
+		$sitemap_repository        = $this->createStub( SitemapRepositoryInterface::class );
+		$taxonomy_sitemap_service  = $this->createStub( TaxonomySitemapService::class );
+		$author_sitemap_service    = $this->createStub( AuthorSitemapService::class );
+		$page_sitemap_service      = $this->createStub( PageSitemapService::class );
+		$action_handlers           = $this->createStub( ActionHandlers::class );
 		$plugin_file_path          = '/path/to/plugin/msm-sitemap.php';
 		$plugin_version            = '1.5.2';
 
@@ -105,15 +105,15 @@ class UITest extends TestCase {
 	 * Test that the UI class setup method can be called.
 	 */
 	public function test_ui_setup_can_be_called(): void {
-		$cron_management           = $this->createMock( CronManagementService::class );
-		$missing_detection_service = $this->createMock( MissingSitemapDetectionService::class );
-		$stats_service             = $this->createMock( SitemapStatsService::class );
-		$settings_service          = $this->createMock( SettingsService::class );
-		$sitemap_repository        = $this->createMock( SitemapRepositoryInterface::class );
-		$taxonomy_sitemap_service  = $this->createMock( TaxonomySitemapService::class );
-		$author_sitemap_service    = $this->createMock( AuthorSitemapService::class );
-		$page_sitemap_service      = $this->createMock( PageSitemapService::class );
-		$action_handlers           = $this->createMock( ActionHandlers::class );
+		$cron_management           = $this->createStub( CronManagementService::class );
+		$missing_detection_service = $this->createStub( MissingSitemapDetectionService::class );
+		$stats_service             = $this->createStub( SitemapStatsService::class );
+		$settings_service          = $this->createStub( SettingsService::class );
+		$sitemap_repository        = $this->createStub( SitemapRepositoryInterface::class );
+		$taxonomy_sitemap_service  = $this->createStub( TaxonomySitemapService::class );
+		$author_sitemap_service    = $this->createStub( AuthorSitemapService::class );
+		$page_sitemap_service      = $this->createStub( PageSitemapService::class );
+		$action_handlers           = $this->createStub( ActionHandlers::class );
 		$plugin_file_path          = '/path/to/plugin/msm-sitemap.php';
 		$plugin_version            = '1.5.2';
 


### PR DESCRIPTION
## Summary

PHPUnit provides two factory methods for test doubles: `createMock()` for mocks that verify interactions via `expects()`, and `createStub()` for stubs that simply return canned values. The test suite was using `createMock()` universally, regardless of whether the test double actually had expectations configured.

This replaces 73 of the 74 `createMock()` calls with `createStub()`, leaving only the single instance in `CoreIntegrationTest` that genuinely verifies `add_provider` is called exactly three times. The change is purely semantic today (both return `MockObject` in PHPUnit 9), but it communicates intent more clearly and prepares for PHPUnit 12, which [enforces this distinction at runtime](https://phpunit.expert/articles/testing-with-and-without-dependencies.html) — configuring expectations on a stub will fail, and creating a mock without expectations will trigger a warning.

No `createStub()` calls existed previously, so there were no instances of the reverse problem (stubs with expectations).

## Test plan

- [ ] Integration tests pass — the change is a like-for-like replacement with no behavioural difference under PHPUnit 9