### PR TITLE
Add property-based tests for value objects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
 	"require-dev": {
 		"automattic/vipwpcs": "^3.0",
 		"ergebnis/phpunit-slow-test-detector": "^2.19",
+		"giorgiosironi/eris": "^0.14",
 		"php-parallel-lint/php-parallel-lint": "^1.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"phpunit/phpcov": "^8.2",

--- a/tests/Generators/SitemapDateGenerator.php
+++ b/tests/Generators/SitemapDateGenerator.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Custom Eris generator for valid SitemapDate objects.
+ *
+ * Generates SitemapDate instances with valid year/month/day combinations.
+ * Uses checkdate() to guarantee that generated dates are real calendar dates.
+ *
+ * @package Automattic\MSM_Sitemap\Tests\Generators
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\MSM_Sitemap\Tests\Generators;
+
+use Automattic\MSM_Sitemap\Domain\ValueObjects\SitemapDate;
+use Eris\Generator;
+use Eris\Generator\GeneratedValue;
+use Eris\Generator\GeneratedValueSingle;
+use Eris\Random\RandomRange;
+
+/**
+ * Generates valid SitemapDate instances for property-based testing.
+ */
+class SitemapDateGenerator implements Generator {
+
+	/**
+	 * Minimum year to generate.
+	 *
+	 * @var int
+	 */
+	private int $min_year;
+
+	/**
+	 * Maximum year to generate.
+	 *
+	 * @var int
+	 */
+	private int $max_year;
+
+	/**
+	 * Days per month (non-leap year maximums, adjusted at generation time).
+	 *
+	 * @var array<int, int>
+	 */
+	private const DAYS_IN_MONTH = array(
+		1  => 31,
+		2  => 29,
+		3  => 31,
+		4  => 30,
+		5  => 31,
+		6  => 30,
+		7  => 31,
+		8  => 31,
+		9  => 30,
+		10 => 31,
+		11 => 30,
+		12 => 31,
+	);
+
+	/**
+	 * Constructor.
+	 *
+	 * @param int $min_year Minimum year to generate (default 2000).
+	 * @param int $max_year Maximum year to generate (default 2030).
+	 */
+	public function __construct( int $min_year = 2000, int $max_year = 2030 ) {
+		$this->min_year = $min_year;
+		$this->max_year = $max_year;
+	}
+
+	/**
+	 * Generate a valid SitemapDate.
+	 *
+	 * @param int         $_size The generation size.
+	 * @param RandomRange $rand  The random number generator.
+	 * @return GeneratedValueSingle The generated SitemapDate value.
+	 */
+	public function __invoke( $_size, RandomRange $rand ) {
+		$year  = $rand->rand( $this->min_year, $this->max_year );
+		$month = $rand->rand( 1, 12 );
+
+		$max_day = self::DAYS_IN_MONTH[ $month ];
+		// Adjust for February in non-leap years.
+		if ( 2 === $month && ! checkdate( 2, 29, $year ) ) {
+			$max_day = 28;
+		}
+
+		$day = $rand->rand( 1, $max_day );
+
+		$date = new SitemapDate( $year, $month, $day );
+
+		return GeneratedValueSingle::fromJustValue( $date, 'sitemap-date' );
+	}
+
+	/**
+	 * Shrink a generated SitemapDate towards a simpler form.
+	 *
+	 * @param GeneratedValue $element The value to shrink.
+	 * @return GeneratedValueSingle The shrunk value.
+	 */
+	public function shrink( GeneratedValue $element ) {
+		$date = $element->unbox();
+
+		if ( ! $date instanceof SitemapDate ) {
+			return GeneratedValueSingle::fromJustValue(
+				new SitemapDate( 2024, 1, 1 ),
+				'sitemap-date'
+			);
+		}
+
+		// Shrink towards 2024-01-01 by reducing each component.
+		$year  = $date->year();
+		$month = $date->month();
+		$day   = $date->day();
+
+		if ( $day > 1 ) {
+			return GeneratedValueSingle::fromJustValue(
+				new SitemapDate( $year, $month, $day - 1 ),
+				'sitemap-date'
+			);
+		}
+
+		if ( $month > 1 ) {
+			return GeneratedValueSingle::fromJustValue(
+				new SitemapDate( $year, $month - 1, 1 ),
+				'sitemap-date'
+			);
+		}
+
+		if ( $year > $this->min_year ) {
+			return GeneratedValueSingle::fromJustValue(
+				new SitemapDate( $year - 1, 1, 1 ),
+				'sitemap-date'
+			);
+		}
+
+		return $element;
+	}
+}

--- a/tests/Generators/ValidUrlGenerator.php
+++ b/tests/Generators/ValidUrlGenerator.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Custom Eris generator for valid URLs.
+ *
+ * Generates syntactically valid URLs suitable for use with UrlEntry and ImageEntry
+ * value objects. URLs are always well-formed HTTPS URLs within the 2048 character limit.
+ *
+ * @package Automattic\MSM_Sitemap\Tests\Generators
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\MSM_Sitemap\Tests\Generators;
+
+use Eris\Generator;
+use Eris\Generator\GeneratedValue;
+use Eris\Generator\GeneratedValueSingle;
+use Eris\Random\RandomRange;
+
+/**
+ * Generates valid HTTPS URLs for property-based testing.
+ */
+class ValidUrlGenerator implements Generator {
+
+	/**
+	 * Example path segments to build URLs from.
+	 *
+	 * @var array<string>
+	 */
+	private const PATH_SEGMENTS = array(
+		'page',
+		'post',
+		'article',
+		'category',
+		'tag',
+		'archive',
+		'about',
+		'contact',
+		'products',
+		'services',
+		'blog',
+		'news',
+		'help',
+		'faq',
+		'docs',
+		'api',
+		'users',
+		'settings',
+	);
+
+	/**
+	 * Example domains to build URLs from.
+	 *
+	 * @var array<string>
+	 */
+	private const DOMAINS = array(
+		'example.com',
+		'test.org',
+		'sample.net',
+		'demo.io',
+		'mysite.com',
+	);
+
+	/**
+	 * Generate a valid URL.
+	 *
+	 * @param int         $_size The generation size (controls complexity).
+	 * @param RandomRange $rand  The random number generator.
+	 * @return GeneratedValueSingle The generated URL value.
+	 */
+	public function __invoke( $_size, RandomRange $rand ) {
+		$domain_index = $rand->rand( 0, count( self::DOMAINS ) - 1 );
+		$domain       = self::DOMAINS[ $domain_index ];
+
+		$num_segments = $rand->rand( 1, min( 4, max( 1, (int) ( $_size / 50 ) + 1 ) ) );
+		$path_parts   = array();
+		for ( $i = 0; $i < $num_segments; $i++ ) {
+			$segment_index = $rand->rand( 0, count( self::PATH_SEGMENTS ) - 1 );
+			$path_parts[]  = self::PATH_SEGMENTS[ $segment_index ];
+			// Sometimes add a numeric suffix.
+			if ( $rand->rand( 0, 2 ) === 0 ) {
+				$path_parts[ count( $path_parts ) - 1 ] .= $rand->rand( 1, 9999 );
+			}
+		}
+
+		$url = 'https://' . $domain . '/' . implode( '/', $path_parts );
+
+		return GeneratedValueSingle::fromJustValue( $url, 'valid-url' );
+	}
+
+	/**
+	 * Shrink a generated URL towards a simpler form.
+	 *
+	 * @param GeneratedValue $element The value to shrink.
+	 * @return GeneratedValueSingle The shrunk value.
+	 */
+	public function shrink( GeneratedValue $element ) {
+		return GeneratedValueSingle::fromJustValue(
+			'https://example.com/page',
+			'valid-url'
+		);
+	}
+}

--- a/tests/Unit/Domain/ValueObjects/GenerationProgressTest.php
+++ b/tests/Unit/Domain/ValueObjects/GenerationProgressTest.php
@@ -12,6 +12,8 @@ namespace Automattic\MSM_Sitemap\Tests\Unit\Domain\ValueObjects;
 use Automattic\MSM_Sitemap\Domain\ValueObjects\GenerationProgress;
 use Automattic\MSM_Sitemap\Domain\ValueObjects\SitemapDate;
 use Automattic\MSM_Sitemap\Tests\Unit\TestCase;
+use Eris\Generators;
+use Eris\TestTrait;
 
 /**
  * GenerationProgress Value Object test case.
@@ -23,6 +25,8 @@ use Automattic\MSM_Sitemap\Tests\Unit\TestCase;
  * - Immutability (withDateCompleted, withCancelled return new instances)
  */
 class GenerationProgressTest extends TestCase {
+
+	use TestTrait;
 
 	// ===========================================
 	// Factory method tests
@@ -433,5 +437,202 @@ class GenerationProgressTest extends TestCase {
 
 		// Equals doesn't compare current_date.
 		$this->assertTrue( $progress1->equals( $progress2 ) );
+	}
+
+	// ===========================================
+	// Property-based tests (Eris)
+	// ===========================================
+
+	/**
+	 * Property: completed equals total minus remaining.
+	 *
+	 * For any valid GenerationProgress, the completed() value must
+	 * always equal total() - remaining(). This is the fundamental
+	 * invariant of the progress calculation.
+	 */
+	public function test_property_completed_equals_total_minus_remaining(): void {
+		$this
+			->forAll(
+				Generators::choose( 0, 10000 ),
+				Generators::choose( 0, 10000 )
+			)
+			->then( function ( int $total, int $remaining ): void {
+				$progress = new GenerationProgress( true, $total, $remaining );
+
+				$this->assertSame(
+					$progress->total() - $progress->remaining(),
+					$progress->completed(),
+					sprintf(
+						'completed (%d) must equal total (%d) - remaining (%d)',
+						$progress->completed(),
+						$progress->total(),
+						$progress->remaining()
+					)
+				);
+			} );
+	}
+
+	/**
+	 * Property: percentComplete is always in [0.0, 100.0].
+	 *
+	 * Regardless of the total and remaining values provided,
+	 * the percentage must be a valid percentage value.
+	 */
+	public function test_property_percent_complete_in_valid_range(): void {
+		$this
+			->forAll(
+				Generators::choose( 0, 10000 ),
+				Generators::choose( 0, 10000 )
+			)
+			->then( function ( int $total, int $remaining ): void {
+				$progress = new GenerationProgress( true, $total, $remaining );
+				$percent  = $progress->percentComplete();
+
+				$this->assertGreaterThanOrEqual(
+					0.0,
+					$percent,
+					'percentComplete must be >= 0.0'
+				);
+				$this->assertLessThanOrEqual(
+					100.0,
+					$percent,
+					'percentComplete must be <= 100.0'
+				);
+			} );
+	}
+
+	/**
+	 * Property: remaining is always clamped to [0, total] after normalisation.
+	 *
+	 * The constructor normalises negative values to 0 and caps remaining
+	 * at total. This property verifies the invariant holds for any inputs.
+	 */
+	public function test_property_remaining_always_in_zero_to_total_range(): void {
+		$this
+			->forAll(
+				Generators::choose( -100, 10000 ),
+				Generators::choose( -100, 10000 )
+			)
+			->then( function ( int $total, int $remaining ): void {
+				$progress = new GenerationProgress( true, $total, $remaining );
+
+				$this->assertGreaterThanOrEqual(
+					0,
+					$progress->remaining(),
+					'remaining must be >= 0 after normalisation'
+				);
+				$this->assertLessThanOrEqual(
+					$progress->total(),
+					$progress->remaining(),
+					'remaining must be <= total after normalisation'
+				);
+			} );
+	}
+
+	/**
+	 * Property: total is always non-negative after normalisation.
+	 *
+	 * Negative total values are normalised to 0 by the constructor.
+	 */
+	public function test_property_total_always_non_negative(): void {
+		$this
+			->forAll(
+				Generators::choose( -1000, 10000 )
+			)
+			->then( function ( int $total ): void {
+				$progress = new GenerationProgress( true, $total, 0 );
+
+				$this->assertGreaterThanOrEqual(
+					0,
+					$progress->total(),
+					sprintf( 'total must be >= 0 after normalisation, got %d for input %d', $progress->total(), $total )
+				);
+			} );
+	}
+
+	/**
+	 * Property: reflexive equality holds for any GenerationProgress.
+	 *
+	 * Every progress instance must be equal to itself.
+	 */
+	public function test_property_reflexive_equality(): void {
+		$this
+			->forAll(
+				Generators::bool(),
+				Generators::choose( 0, 10000 ),
+				Generators::choose( 0, 10000 )
+			)
+			->then( function ( bool $in_progress, int $total, int $remaining ): void {
+				$progress = new GenerationProgress( $in_progress, $total, $remaining );
+
+				$this->assertTrue(
+					$progress->equals( $progress ),
+					'GenerationProgress must be equal to itself'
+				);
+			} );
+	}
+
+	/**
+	 * Property: toArray completed value is consistent with completed().
+	 *
+	 * The 'completed' key in toArray() must always match the value
+	 * returned by the completed() method.
+	 */
+	public function test_property_to_array_completed_matches_method(): void {
+		$this
+			->forAll(
+				Generators::bool(),
+				Generators::choose( 0, 10000 ),
+				Generators::choose( 0, 10000 )
+			)
+			->then( function ( bool $in_progress, int $total, int $remaining ): void {
+				$progress = new GenerationProgress( $in_progress, $total, $remaining );
+				$array    = $progress->toArray();
+
+				$this->assertSame(
+					$progress->completed(),
+					$array['completed'],
+					'toArray completed must match completed() method'
+				);
+				$this->assertSame(
+					$progress->total(),
+					$array['total'],
+					'toArray total must match total() method'
+				);
+				$this->assertSame(
+					$progress->remaining(),
+					$array['remaining'],
+					'toArray remaining must match remaining() method'
+				);
+				$this->assertSame(
+					$progress->isInProgress(),
+					$array['in_progress'],
+					'toArray in_progress must match isInProgress() method'
+				);
+			} );
+	}
+
+	/**
+	 * Property: percentComplete is 0.0 when total is 0.
+	 *
+	 * A zero total should always produce 0.0% to avoid division by zero.
+	 */
+	public function test_property_percent_complete_zero_when_total_zero(): void {
+		$this
+			->forAll(
+				Generators::choose( -100, 0 )
+			)
+			->then( function ( int $total ): void {
+				$progress = new GenerationProgress( false, $total, 0 );
+
+				// After normalisation, total will be 0 for non-positive inputs.
+				if ( 0 === $progress->total() ) {
+					$this->assertSame(
+						0.0,
+						$progress->percentComplete(),
+						'percentComplete must be 0.0 when total is 0'
+					);
+				}
+			} );
 	}
 }

--- a/tests/Unit/Domain/ValueObjects/SitemapContentTest.php
+++ b/tests/Unit/Domain/ValueObjects/SitemapContentTest.php
@@ -11,7 +11,10 @@ namespace Automattic\MSM_Sitemap\Tests\Unit\Domain\ValueObjects;
 
 use Automattic\MSM_Sitemap\Domain\ValueObjects\SitemapContent;
 use Automattic\MSM_Sitemap\Domain\ValueObjects\UrlEntry;
+use Automattic\MSM_Sitemap\Tests\Generators\ValidUrlGenerator;
 use Automattic\MSM_Sitemap\Tests\Unit\TestCase;
+use Eris\Generators;
+use Eris\TestTrait;
 use InvalidArgumentException;
 
 /**
@@ -24,6 +27,8 @@ use InvalidArgumentException;
  * - contains() uses equality comparison (not strict identity)
  */
 class SitemapContentTest extends TestCase {
+
+	use TestTrait;
 
 	/**
 	 * Test that empty content can be created.
@@ -357,5 +362,125 @@ class SitemapContentTest extends TestCase {
 
 		$this->assertCount( 3, $content );
 		$this->assertSame( 3, $content->count() );
+	}
+
+	// ===========================================
+	// Property-based tests (Eris)
+	// ===========================================
+
+	/**
+	 * Property: add() returns a new instance (immutability).
+	 *
+	 * Adding an entry to SitemapContent must always return a different
+	 * object, leaving the original unchanged. This guarantees immutability.
+	 */
+	public function test_property_add_returns_new_instance(): void {
+		$this
+			->forAll(
+				new ValidUrlGenerator()
+			)
+			->then( function ( string $url ): void {
+				$content    = new SitemapContent();
+				$entry      = new UrlEntry( $url );
+				$newContent = $content->add( $entry );
+
+				$this->assertNotSame(
+					$content,
+					$newContent,
+					'add() must return a new SitemapContent instance'
+				);
+				$this->assertCount( 0, $content, 'Original must remain empty' );
+				$this->assertCount( 1, $newContent, 'New instance must have 1 entry' );
+			} );
+	}
+
+	/**
+	 * Property: add() increments count by exactly 1 (when not full).
+	 *
+	 * For any non-full SitemapContent, adding one entry should increase
+	 * the count by exactly one.
+	 */
+	public function test_property_add_increments_count_by_one(): void {
+		$this
+			->forAll(
+				Generators::choose( 0, 9 ),
+				new ValidUrlGenerator()
+			)
+			->then( function ( int $initial_count, string $new_url ): void {
+				// Build initial content with $initial_count entries.
+				$entries = array();
+				for ( $i = 0; $i < $initial_count; $i++ ) {
+					$entries[] = new UrlEntry( "https://example.com/page{$i}" );
+				}
+				$content = new SitemapContent( $entries );
+				$this->assertCount( $initial_count, $content );
+
+				$entry      = new UrlEntry( $new_url );
+				$newContent = $content->add( $entry );
+
+				$this->assertSame(
+					$initial_count + 1,
+					$newContent->count(),
+					sprintf(
+						'Count should increment from %d to %d after add()',
+						$initial_count,
+						$initial_count + 1
+					)
+				);
+			} );
+	}
+
+	/**
+	 * Property: the original SitemapContent is unchanged after add().
+	 *
+	 * Since SitemapContent is immutable, the count of the original
+	 * instance must remain the same after calling add().
+	 */
+	public function test_property_original_unchanged_after_add(): void {
+		$this
+			->forAll(
+				Generators::choose( 0, 5 ),
+				new ValidUrlGenerator()
+			)
+			->then( function ( int $initial_count, string $new_url ): void {
+				$entries = array();
+				for ( $i = 0; $i < $initial_count; $i++ ) {
+					$entries[] = new UrlEntry( "https://example.com/page{$i}" );
+				}
+				$content       = new SitemapContent( $entries );
+				$original_count = $content->count();
+
+				$content->add( new UrlEntry( $new_url ) );
+
+				$this->assertSame(
+					$original_count,
+					$content->count(),
+					'Original SitemapContent must not be modified by add()'
+				);
+			} );
+	}
+
+	/**
+	 * Property: reflexive equality holds for any SitemapContent.
+	 *
+	 * Every SitemapContent must be equal to itself.
+	 */
+	public function test_property_reflexive_equality(): void {
+		$this
+			->forAll(
+				Generators::choose( 0, 5 )
+			)
+			->then( function ( int $count ): void {
+				$entries = array();
+				for ( $i = 0; $i < $count; $i++ ) {
+					$entries[] = new UrlEntry( "https://example.com/page{$i}" );
+				}
+				$content = new SitemapContent( $entries );
+
+				$this->assertTrue(
+					$content->equals( $content ),
+					'SitemapContent must be equal to itself'
+				);
+			} );
 	}
 }

--- a/tests/Unit/Domain/ValueObjects/SitemapDateTest.php
+++ b/tests/Unit/Domain/ValueObjects/SitemapDateTest.php
@@ -10,7 +10,9 @@ declare( strict_types=1 );
 namespace Automattic\MSM_Sitemap\Tests\Unit\Domain\ValueObjects;
 
 use Automattic\MSM_Sitemap\Domain\ValueObjects\SitemapDate;
+use Automattic\MSM_Sitemap\Tests\Generators\SitemapDateGenerator;
 use Automattic\MSM_Sitemap\Tests\Unit\TestCase;
+use Eris\TestTrait;
 use InvalidArgumentException;
 
 /**
@@ -24,6 +26,8 @@ use InvalidArgumentException;
  * - Immutability
  */
 class SitemapDateTest extends TestCase {
+
+	use TestTrait;
 
 	// ===========================================
 	// Constructor validation tests
@@ -459,5 +463,183 @@ class SitemapDateTest extends TestCase {
 			'November 30'  => array( 11, 30 ),
 			'December 31'  => array( 12, 31 ),
 		);
+	}
+
+	// ===========================================
+	// Property-based tests (Eris)
+	// ===========================================
+
+	/**
+	 * Property: trichotomy holds for any two SitemapDates.
+	 *
+	 * For any two dates A and B, exactly one of these is true:
+	 * - A->isBefore(B)
+	 * - A->equals(B)
+	 * - A->isAfter(B)
+	 *
+	 * This is a fundamental ordering property that ensures the comparison
+	 * methods form a total order over the date domain.
+	 */
+	public function test_property_trichotomy_exactly_one_comparison_holds(): void {
+		$this
+			->forAll(
+				new SitemapDateGenerator(),
+				new SitemapDateGenerator()
+			)
+			->then( function ( SitemapDate $a, SitemapDate $b ): void {
+				$is_before = $a->isBefore( $b );
+				$is_equal  = $a->equals( $b );
+				$is_after  = $a->isAfter( $b );
+
+				$true_count = (int) $is_before + (int) $is_equal + (int) $is_after;
+
+				$this->assertSame(
+					1,
+					$true_count,
+					sprintf(
+						'Exactly one of isBefore/equals/isAfter should hold for %s vs %s. Got: before=%s, equal=%s, after=%s',
+						$a->toString(),
+						$b->toString(),
+						$is_before ? 'true' : 'false',
+						$is_equal ? 'true' : 'false',
+						$is_after ? 'true' : 'false'
+					)
+				);
+			} );
+	}
+
+	/**
+	 * Property: isBefore implies isAfter in reverse (anti-symmetry).
+	 *
+	 * If A->isBefore(B), then B->isAfter(A) must also hold.
+	 * This ensures the ordering is consistent in both directions.
+	 */
+	public function test_property_is_before_implies_is_after_in_reverse(): void {
+		$this
+			->forAll(
+				new SitemapDateGenerator(),
+				new SitemapDateGenerator()
+			)
+			->then( function ( SitemapDate $a, SitemapDate $b ): void {
+				if ( $a->isBefore( $b ) ) {
+					$this->assertTrue(
+						$b->isAfter( $a ),
+						sprintf(
+							'If %s isBefore %s, then %s should be isAfter %s',
+							$a->toString(),
+							$b->toString(),
+							$b->toString(),
+							$a->toString()
+						)
+					);
+				}
+
+				if ( $a->isAfter( $b ) ) {
+					$this->assertTrue(
+						$b->isBefore( $a ),
+						sprintf(
+							'If %s isAfter %s, then %s should be isBefore %s',
+							$a->toString(),
+							$b->toString(),
+							$b->toString(),
+							$a->toString()
+						)
+					);
+				}
+			} );
+	}
+
+	/**
+	 * Property: toString roundtrip preserves the date.
+	 *
+	 * For any valid SitemapDate, converting to string and back via
+	 * fromString should produce an equal date. This guarantees that
+	 * the serialisation format is lossless.
+	 */
+	public function test_property_to_string_roundtrip(): void {
+		$this
+			->forAll(
+				new SitemapDateGenerator()
+			)
+			->then( function ( SitemapDate $date ): void {
+				$roundtripped = SitemapDate::fromString( $date->toString() );
+
+				$this->assertTrue(
+					$date->equals( $roundtripped ),
+					sprintf(
+						'SitemapDate::fromString(%s)->equals(original) should be true, got %s',
+						$date->toString(),
+						$roundtripped->toString()
+					)
+				);
+			} );
+	}
+
+	/**
+	 * Property: reflexive equality holds for any SitemapDate.
+	 *
+	 * Every date must be equal to itself.
+	 */
+	public function test_property_reflexive_equality(): void {
+		$this
+			->forAll(
+				new SitemapDateGenerator()
+			)
+			->then( function ( SitemapDate $date ): void {
+				$this->assertTrue(
+					$date->equals( $date ),
+					sprintf(
+						'SitemapDate %s must be equal to itself',
+						$date->toString()
+					)
+				);
+			} );
+	}
+
+	/**
+	 * Property: equal dates are never before or after each other.
+	 *
+	 * If A->equals(B), then both isBefore and isAfter must be false.
+	 */
+	public function test_property_equal_dates_are_not_before_or_after(): void {
+		$this
+			->forAll(
+				new SitemapDateGenerator()
+			)
+			->then( function ( SitemapDate $date ): void {
+				$same = SitemapDate::fromString( $date->toString() );
+
+				$this->assertTrue( $date->equals( $same ) );
+				$this->assertFalse(
+					$date->isBefore( $same ),
+					sprintf( 'Equal date %s should not be isBefore itself', $date->toString() )
+				);
+				$this->assertFalse(
+					$date->isAfter( $same ),
+					sprintf( 'Equal date %s should not be isAfter itself', $date->toString() )
+				);
+			} );
+	}
+
+	/**
+	 * Property: toString always produces YYYY-MM-DD format with zero-padding.
+	 *
+	 * The output format must match the pattern with 4-digit year, 2-digit
+	 * month, and 2-digit day separated by hyphens.
+	 */
+	public function test_property_to_string_format_is_consistent(): void {
+		$this
+			->forAll(
+				new SitemapDateGenerator()
+			)
+			->then( function ( SitemapDate $date ): void {
+				$string = $date->toString();
+
+				$this->assertMatchesRegularExpression(
+					'/^\d{4}-\d{2}-\d{2}$/',
+					$string,
+					sprintf( 'toString() output "%s" should match YYYY-MM-DD format', $string )
+				);
+			} );
 	}
 }

--- a/tests/Unit/Domain/ValueObjects/UrlEntryTest.php
+++ b/tests/Unit/Domain/ValueObjects/UrlEntryTest.php
@@ -11,7 +11,10 @@ namespace Automattic\MSM_Sitemap\Tests\Unit\Domain\ValueObjects;
 
 use Automattic\MSM_Sitemap\Domain\ValueObjects\ImageEntry;
 use Automattic\MSM_Sitemap\Domain\ValueObjects\UrlEntry;
+use Automattic\MSM_Sitemap\Tests\Generators\ValidUrlGenerator;
 use Automattic\MSM_Sitemap\Tests\Unit\TestCase;
+use Eris\Generators;
+use Eris\TestTrait;
 use InvalidArgumentException;
 
 /**
@@ -25,6 +28,8 @@ use InvalidArgumentException;
  * - images validation (must be ImageEntry objects, max 1000)
  */
 class UrlEntryTest extends TestCase {
+
+	use TestTrait;
 
 	/**
 	 * Test that a valid URL is accepted with minimal parameters.
@@ -497,5 +502,136 @@ class UrlEntryTest extends TestCase {
 
 		// Note: equals() does not compare images - this is by design per the implementation.
 		$this->assertTrue( $entry1->equals( $entry2 ) );
+	}
+
+	// ===========================================
+	// Property-based tests (Eris)
+	// ===========================================
+
+	/**
+	 * Property: any float in [0.0, 1.0] is a valid priority value.
+	 *
+	 * The sitemap protocol specifies priority as a value between 0.0 and 1.0.
+	 * Any float within this range should be accepted without exception.
+	 */
+	public function test_property_any_priority_in_valid_range_is_accepted(): void {
+		$this
+			->forAll(
+				Generators::choose( 0, 1000 )
+			)
+			->then( function ( int $int_value ): void {
+				// Map integer 0-1000 to float 0.0-1.0 for precise control.
+				$priority = $int_value / 1000.0;
+				$entry    = new UrlEntry( 'https://example.com/page', null, null, $priority );
+
+				$this->assertSame( $priority, $entry->priority() );
+				$this->assertTrue(
+					$entry->priority() >= 0.0 && $entry->priority() <= 1.0,
+					sprintf( 'Priority %f should be within [0.0, 1.0]', $entry->priority() )
+				);
+			} );
+	}
+
+	/**
+	 * Property: any float outside [0.0, 1.0] is rejected as a priority value.
+	 *
+	 * Floats below 0.0 or above 1.0 must always throw InvalidArgumentException.
+	 */
+	public function test_property_any_priority_outside_valid_range_is_rejected(): void {
+		$this
+			->forAll(
+				Generators::choose( 1, 10000 )
+			)
+			->then( function ( int $offset ): void {
+				// Generate a value above 1.0 (from 1.001 to 11.0).
+				$above = 1.0 + ( $offset / 1000.0 );
+				$caught_above = false;
+				try {
+					new UrlEntry( 'https://example.com/page', null, null, $above );
+				} catch ( InvalidArgumentException $e ) {
+					$caught_above = true;
+				}
+				$this->assertTrue(
+					$caught_above,
+					sprintf( 'Priority %f (above 1.0) should be rejected', $above )
+				);
+
+				// Generate a value below 0.0 (from -0.001 to -10.0).
+				$below = -1.0 * ( $offset / 1000.0 );
+				$caught_below = false;
+				try {
+					new UrlEntry( 'https://example.com/page', null, null, $below );
+				} catch ( InvalidArgumentException $e ) {
+					$caught_below = true;
+				}
+				$this->assertTrue(
+					$caught_below,
+					sprintf( 'Priority %f (below 0.0) should be rejected', $below )
+				);
+			} );
+	}
+
+	/**
+	 * Property: reflexive equality holds for any UrlEntry.
+	 *
+	 * Every UrlEntry must be equal to itself: $x->equals($x) is always true.
+	 */
+	public function test_property_reflexive_equality(): void {
+		$this
+			->forAll(
+				new ValidUrlGenerator(),
+				Generators::elements( 'always', 'hourly', 'daily', 'weekly', 'monthly', 'yearly', 'never' ),
+				Generators::choose( 0, 100 )
+			)
+			->then( function ( string $url, string $changefreq, int $priority_int ): void {
+				$priority = $priority_int / 100.0;
+				$entry    = new UrlEntry( $url, '2024-01-15', $changefreq, $priority );
+
+				$this->assertTrue(
+					$entry->equals( $entry ),
+					'UrlEntry must be equal to itself (reflexive equality)'
+				);
+			} );
+	}
+
+	/**
+	 * Property: to_array always contains the loc key.
+	 *
+	 * The 'loc' field is required by the sitemap protocol and must always
+	 * appear in the array representation, regardless of other optional fields.
+	 */
+	public function test_property_to_array_always_contains_loc(): void {
+		$this
+			->forAll(
+				new ValidUrlGenerator()
+			)
+			->then( function ( string $url ): void {
+				$entry = new UrlEntry( $url );
+				$array = $entry->to_array();
+
+				$this->assertArrayHasKey( 'loc', $array );
+				$this->assertSame( $url, $array['loc'] );
+			} );
+	}
+
+	/**
+	 * Property: to_array includes priority when set, excludes when null.
+	 *
+	 * The priority key should only appear in to_array output when a
+	 * priority value was provided during construction.
+	 */
+	public function test_property_to_array_priority_presence_matches_construction(): void {
+		$this
+			->forAll(
+				Generators::choose( 0, 100 )
+			)
+			->then( function ( int $priority_int ): void {
+				$priority = $priority_int / 100.0;
+				$entry    = new UrlEntry( 'https://example.com/page', null, null, $priority );
+				$array    = $entry->to_array();
+
+				$this->assertArrayHasKey( 'priority', $array );
+				$this->assertSame( $priority, $array['priority'] );
+			} );
 	}
 }


### PR DESCRIPTION
## Summary

The existing unit tests for value objects use hand-picked examples and data providers, which can only sample a fraction of the input space. This introduces property-based testing using the [Eris](https://github.com/giorgiosironi/eris) library, adding 22 test methods that each generate 100 random inputs per run — verifying that algebraic invariants hold across the domain rather than just for specific cases.

The tests target four value objects where the properties are particularly well suited to this approach:

**UrlEntry** — the priority field accepts any float in [0.0, 1.0], a continuous range that hand-picked examples can only sparsely cover. Property tests verify both acceptance and rejection across the range, plus reflexive equality and `to_array()` consistency.

**SitemapDate** — dates have rich ordering properties (trichotomy, anti-symmetry) and a `toString`/`fromString` roundtrip that should be lossless. The existing month-end-days provider only covers a single leap year; random generation explores non-leap years, century years, and arbitrary valid dates.

**SitemapContent** — the immutability contract (add returns a new instance, original unchanged, count increments by exactly one) is a classic invariant that benefits from sequence-based random testing.

**GenerationProgress** — the relationship `completed = total - remaining` and the clamping of `percentComplete` to [0.0, 100.0] are mathematical invariants that hold for any inputs, including edge cases around negative values and zero totals that the constructor normalises.

Two reusable custom generators (`SitemapDateGenerator` and `ValidUrlGenerator`) are provided in `tests/Generators/` for future property tests.

Eris 0.14.x is used rather than 1.0 because the 1.x line uses PHPUnit 10 `#[Before]` attributes that PHPUnit 9 silently ignores, meaning the trait's setup hooks would never fire.

## Test plan

- [ ] `composer test:unit` — all 330 tests pass (including the 22 new property-based tests)
- [ ] Run the unit suite multiple times to confirm stability across different random seeds