### PR TITLE
Lock in 2.x's resilience to the #296 cron date bug

### DIFF
--- a/includes/Infrastructure/Repositories/PostRepository.php
+++ b/includes/Infrastructure/Repositories/PostRepository.php
@@ -181,7 +181,7 @@ class PostRepository implements PostRepositoryInterface {
 		 *
 		 * @param string $query         The query to use to get the last modified posts.
 		 * @param string $post_types_in A comma-separated list of post types to include in the query.
-		 * @param string $date          The date to use as the cutoff for the query.
+		 * @param string $date          The cutoff date in MySQL DATETIME format (UTC), for comparison against post_modified_gmt.
 		 */
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Legacy hook name for backwards compatibility.
 		$query = apply_filters( 'msm_pre_get_last_modified_posts', $query, $post_types_in, $date );

--- a/tests/Integration/PostRepositoryTest.php
+++ b/tests/Integration/PostRepositoryTest.php
@@ -522,4 +522,58 @@ class PostRepositoryTest extends TestCase {
 		$modified_post_ids = array_map( 'intval', wp_list_pluck( $modified_posts, 'ID' ) );
 		$this->assertContains( (int) $post_id, $modified_post_ids );
 	}
+
+	/**
+	 * Regression guard for the 1.5.4 cron bug (#296) when ported into 2.x's
+	 * PostRepository: ensure get_modified_posts_since finds recently modified
+	 * posts on a site configured for a negative-offset timezone.
+	 *
+	 * The original bug formatted the cutoff in server-local time and then
+	 * passed it through get_gmt_from_date(), re-applying the site offset.
+	 * On negative-offset sites this pushed the cutoff into the future and
+	 * the query against post_modified_gmt found no posts.
+	 *
+	 * 2.x rewrote the function to use gmdate() directly, which sidesteps
+	 * the bug. This test locks that in so a future refactor cannot silently
+	 * reintroduce the local-time round trip.
+	 */
+	public function test_get_modified_posts_since_finds_posts_in_negative_offset_timezone(): void {
+		$original_timezone = get_option( 'timezone_string' );
+		update_option( 'timezone_string', 'America/New_York' );
+		wp_cache_flush();
+
+		try {
+			$post_id = $this->create_dummy_post( '2020-01-01 00:00:00' );
+
+			wp_update_post(
+				array(
+					'ID'         => $post_id,
+					'post_title' => 'Updated Title',
+				)
+			);
+
+			global $wpdb;
+			$wpdb->update(
+				$wpdb->posts,
+				array(
+					'post_modified_gmt' => gmdate( 'Y-m-d H:i:s' ),
+					'post_modified'     => date( 'Y-m-d H:i:s' ),
+				),
+				array( 'ID' => $post_id )
+			);
+			clean_post_cache( $post_id );
+
+			$modified_posts    = $this->repository->get_modified_posts_since( time() - 3600 );
+			$modified_post_ids = array_map( 'intval', wp_list_pluck( $modified_posts, 'ID' ) );
+
+			$this->assertContains(
+				(int) $post_id,
+				$modified_post_ids,
+				'Should find post modified within last hour on a negative-offset site (regression guard for #296).'
+			);
+		} finally {
+			update_option( 'timezone_string', $original_timezone ?: '' );
+			wp_cache_flush();
+		}
+	}
 }


### PR DESCRIPTION
## Summary

[#296](https://github.com/Automattic/msm-sitemap/issues/296) reported that incremental sitemap updates silently stopped on negative-offset timezones in 1.5.4. The cause was a local-time round trip through `get_gmt_from_date()` that re-applied the site offset and pushed the cutoff into the future. PR [#297](https://github.com/Automattic/msm-sitemap/pull/297) fixed that on `develop`.

While reviewing whether the same fix needed porting to 2.x, I found that the equivalent function — `PostRepository::get_modified_posts_since()` — already uses `gmdate()` directly and skips the local-time round trip. The refactor accidentally fixed the bug. Nothing currently guards against a future refactor reintroducing it, though: the existing `test_get_modified_posts_since` runs in the default UTC timezone, and the broader `TimezoneTest` is `markTestSkipped`'d pending its own DDD refactor (with a `@todo` to that effect).

This PR adds a regression guard in `America/New_York` so the absence of the bug is a tested property rather than a happy accident.

It also clarifies the `msm_pre_get_last_modified_posts` filter docblock to specify that the `$date` argument is UTC. The 1.x docblock had the same vague wording and contributed to the confusion that produced the original bug — worth fixing while we're here.

No production behaviour changes.

## Test plan

- [ ] Integration tests pass in CI, including the new `test_get_modified_posts_since_finds_posts_in_negative_offset_timezone`
- [ ] Confirm the new test would have failed against the pre-#297 1.5.4 implementation (negative-offset cutoff was pushed into the future, so the assertion would fail)